### PR TITLE
[IMP][14.0] pms to assign reservation flow

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -87,6 +87,7 @@ class PmsReservation(models.Model):
         copy=False,
         store=True,
         comodel_name="pms.room.type",
+        ondelete="restrict",
         compute="_compute_room_type_id",
         tracking=True,
         check_pms_properties=True,

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -313,9 +313,9 @@ class PmsReservation(models.Model):
     )
     to_assign = fields.Boolean(
         string="To Assign",
-        help="Technical field",
+        help="It is True if the room of the reservation has been assigned "
+        "automatically, False if it was confirmed by a person in charge",
         default=True,
-        tracking=True,
     )
     state = fields.Selection(
         string="State",
@@ -615,6 +615,12 @@ class PmsReservation(models.Model):
 
     @api.depends("preferred_room_id")
     def _compute_room_type_id(self):
+        """
+        This method set False to_assign when the user
+        directly chooses the preferred_room_id,
+        otherwise, action_assign will be used when the user manually confirms
+        or changes the preferred_room_id of the reservation
+        """
         for reservation in self:
             if reservation.preferred_room_id and not reservation.room_type_id:
                 reservation.room_type_id = reservation.preferred_room_id.room_type_id.id

--- a/pms/models/pms_reservation_line.py
+++ b/pms/models/pms_reservation_line.py
@@ -176,6 +176,8 @@ class PmsReservationLine(models.Model):
 
                 # Check if the room assigment is manual or automatic to set the
                 # to_assign value on reservation
+                # REVIEW: SRP Issue?¿ (set reservation to_assign value on
+                # compute_room_id in reservation_line)
                 if (
                     free_room_select
                     and reservation.preferred_room_id.id

--- a/pms/models/pms_reservation_line.py
+++ b/pms/models/pms_reservation_line.py
@@ -173,6 +173,17 @@ class PmsReservationLine(models.Model):
                 and not line.room_id
             ):
                 free_room_select = True if reservation.preferred_room_id else False
+
+                # Check if the room assigment is manual or automatic to set the
+                # to_assign value on reservation
+                if (
+                    free_room_select
+                    and reservation.preferred_room_id.id
+                    not in reservation.reservation_line_ids.room_id.ids
+                ):
+                    # This case is a preferred_room_id manually assigned
+                    reservation.to_assign = False
+
                 # we get the rooms available for the entire stay
                 rooms_available = self.env["pms.availability.plan"].rooms_available(
                     checkin=line.reservation_id.checkin,

--- a/pms/tests/test_pms_reservation.py
+++ b/pms/tests/test_pms_reservation.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 
 @freeze_time("2012-01-14")
@@ -788,8 +788,94 @@ class TestPmsReservations(common.SavepointCase):
         # ASSERT
         self.assertEqual(r1, reservations[0])
 
-    @freeze_time("1981-11-01")
     def test_reservation_action_assign(self):
+        """
+        Checks the correct operation of the assign method
+        ---------------
+        Create a new reservation with only room_type(autoassign -> to_assign = True),
+        and the we call to action_assign method to confirm the assignation
+        """
+        self.create_common_scenario()
+        res = self.env["pms.reservation"].create(
+            {
+                "checkin": fields.date.today(),
+                "checkout": fields.date.today() + datetime.timedelta(days=1),
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.env.ref("base.res_partner_12").id,
+                "pms_property_id": self.property.id,
+            }
+        )
+        # ACT
+        res.action_assign()
+        # ASSERT
+        self.assertFalse(res.to_assign, "The reservation should be marked as assigned")
+
+    def test_reservation_auto_assign_on_create(self):
+        """
+        When creating a reservation with a specific room,
+        it is not necessary to mark it as to be assigned
+        ---------------
+        Create a new reservation with specific preferred_room_id,
+        "to_assign" should be set to false automatically
+        """
+        # ARRANGE
+        self.create_common_scenario()
+
+        # ACT
+        res = self.env["pms.reservation"].create(
+            {
+                "checkin": fields.date.today(),
+                "checkout": fields.date.today() + datetime.timedelta(days=1),
+                "preferred_room_id": self.room1.id,
+                "partner_id": self.env.ref("base.res_partner_12").id,
+                "pms_property_id": self.property.id,
+            }
+        )
+
+        # ASSERT
+        self.assertFalse(
+            res.to_assign, "Reservation with preferred_room_id set to to_assign = True"
+        )
+
+    @tagged("herefail")
+    def test_reservation_auto_assign_after_create(self):
+        """
+        When assigning a room manually to a reservation marked "to be assigned",
+        this field should be automatically unchecked
+        ---------------
+        Create a new reservation without preferred_room_id (only room_type),
+        "to_assign" is True, then set preferred_room_id and "to_assign" should
+        be set to false automatically
+        """
+        # ARRANGE
+        self.create_common_scenario()
+        res = self.env["pms.reservation"].create(
+            {
+                "checkin": fields.date.today(),
+                "checkout": fields.date.today() + datetime.timedelta(days=1),
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.env.ref("base.res_partner_12").id,
+                "pms_property_id": self.property.id,
+            }
+        )
+
+        # ACT
+        # we need to force the change of room assigned automatically (which we do not know)
+        if res.preferred_room_id.id == self.room1.id:
+            res.preferred_room_id = self.room2.id
+        else:
+            res.preferred_room_id.id = self.room1.id
+
+        res.flush()
+
+        # ASSERT
+        self.assertFalse(
+            res.to_assign,
+            "The reservation should be marked as assigned automatically \
+            when assigning the specific room",
+        )
+
+    def test_reservation_to_assign_on_create(self):
         # TEST CASE
         # the reservation action assign
         # change the reservation to 'to_assign' = False

--- a/pms/tests/test_pms_reservation.py
+++ b/pms/tests/test_pms_reservation.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import UserError, ValidationError
-from odoo.tests import common, tagged
+from odoo.tests import common
 
 
 @freeze_time("2012-01-14")
@@ -837,7 +837,6 @@ class TestPmsReservations(common.SavepointCase):
             res.to_assign, "Reservation with preferred_room_id set to to_assign = True"
         )
 
-    @tagged("herefail")
     def test_reservation_auto_assign_after_create(self):
         """
         When assigning a room manually to a reservation marked "to be assigned",
@@ -849,6 +848,10 @@ class TestPmsReservations(common.SavepointCase):
         """
         # ARRANGE
         self.create_common_scenario()
+        # set the priority of the rooms to control the room chosen by auto assign
+        self.room1.sequence = 1
+        self.room2.sequence = 2
+
         res = self.env["pms.reservation"].create(
             {
                 "checkin": fields.date.today(),
@@ -860,13 +863,8 @@ class TestPmsReservations(common.SavepointCase):
         )
 
         # ACT
-        # we need to force the change of room assigned automatically (which we do not know)
-        if res.preferred_room_id.id == self.room1.id:
-            res.preferred_room_id = self.room2.id
-        else:
-            res.preferred_room_id.id = self.room1.id
-
-        res.flush()
+        # res shoul be room1 in preferred_room_id (minor sequence)
+        res.preferred_room_id = self.room2.id
 
         # ASSERT
         self.assertFalse(

--- a/pms/views/pms_reservation_views.xml
+++ b/pms/views/pms_reservation_views.xml
@@ -15,12 +15,20 @@
                     <field name="splitted" invisible="True" />
                     <field name="tax_ids" invisible="1" />
                     <field name="checkin_partner_count" invisible="1" />
+                    <field name="to_assign" invisible="1" />
                     <button
                         name="confirm"
                         string="Confirm"
                         class="oe_highlight"
                         type="object"
                         attrs="{'invisible':[('state','not in',('draft','cancelled'))]}"
+                    />
+                    <button
+                        name="action_assign"
+                        string="Confirm Assigned Room"
+                        class="oe_highlight"
+                        type="object"
+                        attrs="{'invisible':['|',('preferred_room_id','=',False),('to_assign', '=', False)]}"
                     />
                     <button
                         name="action_cancel"


### PR DESCRIPTION
A reservation is check like "to_assign" when the specific room (preferred_room_id) is automatically assigned (the "user" set the room_type but not the specific room). If then the user set the Confirm Assigned Room Button or change de room directly in the form, the to_assign field is set to False:
![To_assign_Flow](https://user-images.githubusercontent.com/11718836/121802509-f70f2100-cc3c-11eb-915f-0e4adbdcaabb.gif)
