### PR TITLE
[14.0][IMP] Compute discounts on cancellation flow

### DIFF
--- a/pms/models/pms_service.py
+++ b/pms/models/pms_service.py
@@ -188,7 +188,6 @@ class PmsService(models.Model):
         store=True,
         digits=("Discount"),
         compute="_compute_discount",
-        tracking=True,
     )
 
     # Compute and Search methods

--- a/pms/views/pms_reservation_views.xml
+++ b/pms/views/pms_reservation_views.xml
@@ -405,6 +405,12 @@
                                 widget="monetary"
                                 options="{'currency_field': 'currency_id'}"
                             />
+                            <field
+                                name="services_discount"
+                                string="Discount Services"
+                                widget="monetary"
+                                options="{'currency_field': 'currency_id'}"
+                            />
                             <field name="price_subtotal" invisible="1" />
                             <div
                                 class="oe_subtotal_footer_separator oe_inline o_td_label"
@@ -542,6 +548,7 @@
                                         <field name="tax_ids" widget="many2many_tags" />
                                         <field name="price_subtotal" />
                                         <field name="price_tax" />
+                                        <field name="discount" />
                                         <field name="price_total" />
                                         <field name="service_line_ids" invisible="1">
                                             <tree string="Days">


### PR DESCRIPTION
When a reservation is cancelled, the services discounts are calculated as follows: in the case of a board_service the discount will be the same as that for the reservation lines, otherwise the discount will always be 100%. Total service discounts and each service line discount have been included in the booking view.

https://user-images.githubusercontent.com/49147098/124304144-9bf98b80-db63-11eb-95e9-3db66cb19871.mp4

