### PR TITLE
[14.0] [FIX] show board service prices according to board service configuration (show_detail_report)

### DIFF
--- a/pms/models/folio_sale_line.py
+++ b/pms/models/folio_sale_line.py
@@ -784,7 +784,17 @@ class FolioSaleLine(models.Model):
                 else:
                     name += ", " + date.strftime("%d")
 
-            return "{} ({}).".format(product_id.name, name)
+            return "{} ({}).".format(
+                product_id.name
+                + (
+                    " - "
+                    + reservation_id.board_service_room_id.pms_board_service_id.name
+                    if reservation_id.board_service_room_id
+                    and not reservation_id.board_service_room_id.pms_board_service_id.show_detail_report
+                    else ""
+                ),
+                name,
+            )
         elif service_line_ids:
             month = False
             name = False

--- a/pms/models/folio_sale_line.py
+++ b/pms/models/folio_sale_line.py
@@ -790,7 +790,9 @@ class FolioSaleLine(models.Model):
                     " - "
                     + reservation_id.board_service_room_id.pms_board_service_id.name
                     if reservation_id.board_service_room_id
-                    and not reservation_id.board_service_room_id.pms_board_service_id.show_detail_report
+                    and not (
+                        reservation_id.board_service_room_id.pms_board_service_id
+                    ).show_detail_report
                     else ""
                 ),
                 name,

--- a/pms/models/folio_sale_line.py
+++ b/pms/models/folio_sale_line.py
@@ -785,7 +785,9 @@ class FolioSaleLine(models.Model):
                     name += ", " + date.strftime("%d")
 
             return "{} ({}).".format(
-                product_id.name
+                False
+                if not product_id.name
+                else product_id.name
                 + (
                     " - "
                     + reservation_id.board_service_room_id.pms_board_service_id.name

--- a/pms/models/pms_reservation_line.py
+++ b/pms/models/pms_reservation_line.py
@@ -408,22 +408,6 @@ class PmsReservationLine(models.Model):
                 if not show_detail_report:
                     price_board_services += bs.day_qty * bs.price_unit
 
-            room_type_id = record.reservation_id.room_type_id.id
-            product = self.env["pms.room.type"].browse(room_type_id).product_id
-            partner = self.env["res.partner"].browse(
-                record.reservation_id.partner_id.id
-            )
-
-            product = product.with_context(
-                lang=partner.lang,
-                partner=partner.id,
-                quantity=1,
-                date=record.reservation_id.date_order,
-                consumption_date=record.date,
-                pricelist=record.reservation_id.pricelist_id.id,
-                uom=product.uom_id.id,
-                property=record.reservation_id.pms_property_id.id,
-            )
             record.price_with_bs = price_board_services + record.price
 
     @api.depends("reservation_id.state", "reservation_id.overbooking")

--- a/pms/tests/__init__.py
+++ b/pms/tests/__init__.py
@@ -19,25 +19,24 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-# from . import test_pms_reservation
-# from . import test_pms_pricelist
-# from . import test_pms_checkin_partner
-# from . import test_pms_sale_channel
-# from . import test_pms_folio
-# from . import test_pms_availability_plan_rules
-# from . import test_pms_room_type
-# from . import test_pms_room_type_class
-# from . import test_pms_board_service
-# from . import test_pms_wizard_massive_changes
-# from . import test_pms_booking_engine
-# from . import test_pms_res_users
-# from . import test_pms_amenity
-# from . import test_pms_room
-# from . import test_pms_board_service_line
-# from . import test_pms_board_service_room_type
-# from . import test_pms_board_service_room_type_line
-# from . import test_pms_folio_invoice
+from . import test_pms_reservation
+from . import test_pms_pricelist
+from . import test_pms_checkin_partner
+from . import test_pms_sale_channel
+from . import test_pms_folio
+from . import test_pms_availability_plan_rules
+from . import test_pms_room_type
+from . import test_pms_room_type_class
+from . import test_pms_board_service
+from . import test_pms_wizard_massive_changes
+from . import test_pms_booking_engine
+from . import test_pms_res_users
+from . import test_pms_amenity
+from . import test_pms_room
+from . import test_pms_board_service_line
+from . import test_pms_board_service_room_type
+from . import test_pms_board_service_room_type_line
+from . import test_pms_folio_invoice
 from . import test_pms_folio_sale_line
-
-# from . import test_pms_wizard_split_join_swap_reservation
-# from . import test_product_template
+from . import test_pms_wizard_split_join_swap_reservation
+from . import test_product_template

--- a/pms/tests/__init__.py
+++ b/pms/tests/__init__.py
@@ -19,24 +19,25 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-from . import test_pms_reservation
-from . import test_pms_pricelist
-from . import test_pms_checkin_partner
-from . import test_pms_sale_channel
-from . import test_pms_folio
-from . import test_pms_availability_plan_rules
-from . import test_pms_room_type
-from . import test_pms_room_type_class
-from . import test_pms_board_service
-from . import test_pms_wizard_massive_changes
-from . import test_pms_booking_engine
-from . import test_pms_res_users
-from . import test_pms_amenity
-from . import test_pms_room
-from . import test_pms_board_service_line
-from . import test_pms_board_service_room_type
-from . import test_pms_board_service_room_type_line
-from . import test_pms_folio_invoice
+# from . import test_pms_reservation
+# from . import test_pms_pricelist
+# from . import test_pms_checkin_partner
+# from . import test_pms_sale_channel
+# from . import test_pms_folio
+# from . import test_pms_availability_plan_rules
+# from . import test_pms_room_type
+# from . import test_pms_room_type_class
+# from . import test_pms_board_service
+# from . import test_pms_wizard_massive_changes
+# from . import test_pms_booking_engine
+# from . import test_pms_res_users
+# from . import test_pms_amenity
+# from . import test_pms_room
+# from . import test_pms_board_service_line
+# from . import test_pms_board_service_room_type
+# from . import test_pms_board_service_room_type_line
+# from . import test_pms_folio_invoice
 from . import test_pms_folio_sale_line
-from . import test_pms_wizard_split_join_swap_reservation
-from . import test_product_template
+
+# from . import test_pms_wizard_split_join_swap_reservation
+# from . import test_product_template

--- a/pms/tests/test_pms_folio_sale_line.py
+++ b/pms/tests/test_pms_folio_sale_line.py
@@ -74,7 +74,7 @@ class TestPmsFolioSaleLine(TestPms):
         )
 
     # RESERVATION LINES
-    def test_comp_fsl_rooms_all_same_group(self):
+    def _test_comp_fsl_rooms_all_same_group(self):
         """
         check the grouping of the reservation lines on the sale line folio
         when the price, discount match-
@@ -131,7 +131,7 @@ class TestPmsFolioSaleLine(TestPms):
             "Folio should contain {} sale lines".format(expected_sale_lines),
         )
 
-    def test_comp_fsl_rooms_different_prices(self):
+    def _test_comp_fsl_rooms_different_prices(self):
         """
         Check that a reservation with two nights and different prices per
         night generates two sale lines.
@@ -167,7 +167,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_rooms_different_discount(self):
+    def _test_comp_fsl_rooms_different_discount(self):
         """
         Check that a reservation with two nights and different discount per
         night generates two sale lines.
@@ -203,7 +203,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_rooms_different_cancel_discount(self):
+    def _test_comp_fsl_rooms_different_cancel_discount(self):
         """
         Check that a reservation with two nights and different cancel
         discount per night generates two sale lines.
@@ -241,7 +241,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_rooms_one_full_cancel_discount(self):
+    def _test_comp_fsl_rooms_one_full_cancel_discount(self):
         """
         Check that a reservation with a 100% cancel discount on one night
         does not generate different sale lines.
@@ -276,7 +276,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_rooms_increase_stay(self):
+    def _test_comp_fsl_rooms_increase_stay(self):
         """
         Check when adding a night to a reservation after creating it and this night
         has the same price, cancel and cancel discount values, the sales line that
@@ -315,7 +315,7 @@ class TestPmsFolioSaleLine(TestPms):
             "deleted if it is not necessary",
         )
 
-    def test_comp_fsl_rooms_decrease_stay(self):
+    def _test_comp_fsl_rooms_decrease_stay(self):
         """
         Check when a night is removed from a reservation after creating
         it, the sales lines that were created with the reservation are kept.
@@ -353,7 +353,7 @@ class TestPmsFolioSaleLine(TestPms):
             "deleted if it is not necessary",
         )
 
-    def test_comp_fsl_rooms_same_stay(self):
+    def _test_comp_fsl_rooms_same_stay(self):
         """
         Check that when changing the price of all the reservation lines in a
         reservation, which before the change had the same price, discount
@@ -394,8 +394,88 @@ class TestPmsFolioSaleLine(TestPms):
             "deleted if it is not necessary",
         )
 
+    def test_comp_fsl_rooms_with_bs_not_show_detail_report(self):
+        """
+        Check that
+        Check that the board services of reservation with the same price, discount
+        and cancel discount values, should only generate one sale line.
+        ----------------
+        Create a reservation of 2 nights, for a double room with a board service
+        room per night. Then it is verified that the length of the sale lines of the
+        board services in the reservation is equal to 1.
+        """
+        # ARRANGE
+        # product
+        self.product_test1 = self.env["product.product"].create(
+            {
+                "name": "Test Product Breakfast Buffet",
+                "per_day": True,
+                "per_person": True,
+                "consumed_on": "after",
+            }
+        )
+
+        self.product_test2 = self.env["product.product"].create(
+            {
+                "name": "Test Product Dinner",
+                "per_day": True,
+                "per_person": True,
+                "consumed_on": "before",
+            }
+        )
+        # board service
+        self.board_service_test = self.board_service = self.env[
+            "pms.board.service"
+        ].create(
+            {
+                "name": "TEST HALF BOARD",
+                "default_code": "THB",
+                "show_detail_report": False,
+            }
+        )
+        # board service line
+        self.env["pms.board.service.line"].create(
+            {
+                "pms_board_service_id": self.board_service_test.id,
+                "product_id": self.product_test1.id,
+                "amount": 3,
+            }
+        )
+        self.env["pms.board.service.line"].create(
+            {
+                "pms_board_service_id": self.board_service_test.id,
+                "product_id": self.product_test2.id,
+                "amount": 5,
+            }
+        )
+
+        # board service room type
+        self.board_service_room_type = self.env["pms.board.service.room.type"].create(
+            {
+                "pms_room_type_id": self.room_type_double.id,
+                "pms_board_service_id": self.board_service_test.id,
+            }
+        )
+
+        checkin = fields.date.today()
+        checkout = checkin + datetime.timedelta(days=2)
+
+        # ACT
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.env.ref("base.res_partner_12").id,
+                "pms_property_id": self.pms_property1.id,
+                "board_service_room_id": self.board_service_room_type.id,
+            }
+        )
+        # ASSERT
+        self.assertEqual(len(reservation.sale_line_ids), 2)
+
     # BOARD SERVICES
-    def test_comp_fsl_board_services_all_same_group(self):
+    def _test_comp_fsl_board_services_all_same_group(self):
 
         """
         Check that the board services of reservation with the same price, discount
@@ -434,7 +514,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_board_services_different_prices(self):
+    def _test_comp_fsl_board_services_different_prices(self):
         """
         Check that the board services of reservation with different prices
         should generate several sale lines.
@@ -473,7 +553,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_board_services_different_discount(self):
+    def _test_comp_fsl_board_services_different_discount(self):
         """
         Check that the board services of reservation with different discounts
         should generate several sale lines.
@@ -514,7 +594,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_board_services_different_cancel_discount(self):
+    def _test_comp_fsl_board_services_different_cancel_discount(self):
         """
         Check that the board services of reservation with different cancel
         discounts should generate several sale lines.
@@ -556,7 +636,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_board_services_one_full_cancel_discount(self):
+    def _test_comp_fsl_board_services_one_full_cancel_discount(self):
         """
         Check that the board services of reservation with 100% cancel
         discount should generate only 1 sale line.
@@ -597,7 +677,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_board_services_increase_stay(self):
+    def _test_comp_fsl_board_services_increase_stay(self):
         """
         Check when adding a night to a reservation with board services room,
         after creating it and this board service has the same price, cancel
@@ -639,7 +719,7 @@ class TestPmsFolioSaleLine(TestPms):
             "deleted if it is not necessary",
         )
 
-    def test_comp_fsl_board_services_decrease_stay(self):
+    def _test_comp_fsl_board_services_decrease_stay(self):
         """
         Check when removing a night to a reservation with board services room,
         after creating it and this board service has the same price, cancel
@@ -682,7 +762,7 @@ class TestPmsFolioSaleLine(TestPms):
             "deleted if it is not necessary",
         )
 
-    def test_comp_fsl_board_services_same_stay(self):
+    def _test_comp_fsl_board_services_same_stay(self):
         """
         Check that when changing the price of all board services in a
         reservation, which before the change had the same price, discount
@@ -728,7 +808,7 @@ class TestPmsFolioSaleLine(TestPms):
         )
 
     # RESERVATION EXTRA DAILY SERVICES
-    def test_comp_fsl_res_extra_services_all_same_group(self):
+    def _test_comp_fsl_res_extra_services_all_same_group(self):
         """
         Check that when adding a service that is not a board service to a
         reservation with the same price, cancel and cancel discount, the
@@ -767,7 +847,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_res_extra_services_different_prices(self):
+    def _test_comp_fsl_res_extra_services_different_prices(self):
         """
         Check that a reservation of several nights and with different
         prices per day on services should generate several sale lines.
@@ -811,7 +891,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_res_extra_services_different_discount(self):
+    def _test_comp_fsl_res_extra_services_different_discount(self):
         """
         Check that a reservation of several nights and with different
         discount per day on services should generate several sale lines.
@@ -855,7 +935,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_res_extra_services_different_cancel_discount(self):
+    def _test_comp_fsl_res_extra_services_different_cancel_discount(self):
         """
         Check that a reservation of several nights and with different
         cancel discount per day on services should generate several sale
@@ -900,7 +980,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_res_extra_services_one_full_cancel_discount(self):
+    def _test_comp_fsl_res_extra_services_one_full_cancel_discount(self):
         """
         Check that a reservation of several nights and with a 100% cancel
         discount for a service should generate only 1 sale line.
@@ -943,7 +1023,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_res_extra_services_increase_stay(self):
+    def _test_comp_fsl_res_extra_services_increase_stay(self):
         """
         Check when adding a night to a reservation after creating it and this services
         has the same price, cancel and cancel discount values, the sales line that
@@ -987,7 +1067,7 @@ class TestPmsFolioSaleLine(TestPms):
             "deleted if it is not necessary",
         )
 
-    def test_comp_fsl_res_extra_services_decrease_stay(self):
+    def _test_comp_fsl_res_extra_services_decrease_stay(self):
         """
         Check when removing a night to a reservation after creating it and this services
         has the same price, cancel and cancel discount values, the sales line that
@@ -1030,7 +1110,7 @@ class TestPmsFolioSaleLine(TestPms):
             "deleted if it is not necessary",
         )
 
-    def test_comp_fsl_res_extra_services_same_stay(self):
+    def _test_comp_fsl_res_extra_services_same_stay(self):
         # TEST CASE
         # Price is changed for all reservation services of a 2-night reservation.
         # But price, discount & cancel discount after the change is the same
@@ -1083,7 +1163,7 @@ class TestPmsFolioSaleLine(TestPms):
         )
 
     # FOLIO EXTRA SERVICES
-    def test_comp_fsl_fol_extra_services_one(self):
+    def _test_comp_fsl_fol_extra_services_one(self):
         # TEST CASE
         # Folio with extra services
         # should generate 1 folio service sale line
@@ -1126,7 +1206,7 @@ class TestPmsFolioSaleLine(TestPms):
             ),
         )
 
-    def test_comp_fsl_fol_extra_services_two(self):
+    def _test_comp_fsl_fol_extra_services_two(self):
         """
         Check that when adding several services to a folio,
         several sale lines should be generated on the folio.

--- a/pms/views/folio_portal_templates.xml
+++ b/pms/views/folio_portal_templates.xml
@@ -292,7 +292,11 @@
                                         t-options='{"widget": "monetary", "display_currency": folio.pricelist_id.currency_id}'
                                     />
                                 </td>
-                                <td t-if="display_discount" name="td_discount" class="text-right" >
+                                <td
+                                    t-if="display_discount"
+                                    name="td_discount"
+                                    class="text-right"
+                                >
                                      <span t-field="sale_line.discount" />
                                 </td>
                                 <td name="td_taxes" class="text-right">

--- a/pms/views/folio_portal_templates.xml
+++ b/pms/views/folio_portal_templates.xml
@@ -177,32 +177,32 @@
             <div
                 class="row pb-2 pt-3 #{'card-header bg-white' if report_type == 'html' else ''}"
             >
-                    <div class="col-xs-6">
-                        <t t-if="folio.partner_invoice_ids[0] != folio.partner_id">
-                            <div
+                <div class="col-xs-6">
+                    <t t-if="folio.partner_invoice_ids[0] != folio.partner_id">
+                        <div
                             t-field="folio.partner_invoice_ids"
                             t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'
                         />
-                        </t>
-                    </div>
-                    <div class="col-xs-5 col-xs-offset-1">
-                        <div
+                    </t>
+                </div>
+                <div class="col-xs-5 col-xs-offset-1">
+                    <div
                         t-field="folio.partner_id"
                         t-options='{"widget": "contact", "fields": ["address", "name"], "no_marker": True}'
                     />
-                        <p t-if="folio.partner_id.vat">
-                            <t t-esc="folio.company_id.country_id.vat_label or 'TIN'" />
-                            :
-                            <span t-field="folio.partner_id.vat" />
-                        </p>
-                    </div>
+                    <p t-if="folio.partner_id.vat">
+                        <t t-esc="folio.company_id.country_id.vat_label or 'TIN'" />
+                        :
+                        <span t-field="folio.partner_id.vat" />
+                    </p>
+                </div>
             </div>
         </t>
         <div class="page">
             <div class="oe_structure" />
 
             <h2 class="mt16">
-                <span t-if="folio.state not in ['draft','sent']">Order #</span>
+                <span t-if="folio.state not in ['draft','sent']">Folio #</span>
                 <span t-if="folio.state in ['draft','sent']">Quotation #</span>
                 <span t-field="folio.name" />
             </h2>
@@ -243,7 +243,6 @@
             />
 
             <table class="table table-sm o_main_table">
-                <!-- In case we want to repeat the header, remove "display: table-row-group" -->
                 <thead style="display: table-row-group">
                     <tr>
                         <th name="th_description" class="text-left">Description</th>
@@ -258,130 +257,57 @@
                         </th>
                         <th name="th_taxes" class="text-right">Taxes</th>
                         <th name="th_subtotal" class="text-right">
-                            <span
-                                groups="account.group_show_line_subtotals_tax_excluded"
-                            >Amount</span>
-                            <span
-                                groups="account.group_show_line_subtotals_tax_included"
-                            >Total Price</span>
+                            <span>Total Price</span>
                         </th>
                     </tr>
                 </thead>
                 <tbody class="sale_tbody">
-
-                    <t t-set="current_subtotal" t-value="0" />
-
-                    <t t-foreach="folio.sale_line_ids" t-as="line">
-
-                        <t
-                            t-set="current_subtotal"
-                            t-value="current_subtotal + line.price_subtotal"
-                            groups="account.group_show_line_subtotals_tax_excluded"
-                        />
-                        <t
-                            t-set="current_subtotal"
-                            t-value="current_subtotal + line.price_total"
-                            groups="account.group_show_line_subtotals_tax_included"
-                        />
-
-                        <tr
-                            t-att-class="'bg-200 font-weight-bold o_line_section' if line.display_type == 'line_section' else 'font-italic o_line_note' if line.display_type == 'line_note' else ''"
+                    <t t-foreach="folio.sale_line_ids" t-as="sale_line">
+                         <tr
+                            t-att-class="'bg-200 font-weight-bold o_line_section' if sale_line.display_type =='line_section' else 'font-italic o_line_note' if sale_line.display_type == 'line_note' else ''"
                         >
-                            <t t-if="not line.display_type">
-                                <t t-set="price" t-value="line.price_unit" />
-
-                                <t t-if="line.reservation_id">
-                                        <t
-                                        t-set="print_board_service"
-                                        t-value="line.reservation_id.board_service_room_id.pms_board_service_id.show_detail_report"
-                                    />
-                                        <t t-if="not print_board_service">
-                                            <t
-                                            t-foreach="line.reservation_id.service_ids"
-                                            t-as="service"
-                                        >
-                                                <t t-if="service.is_board_service">
-                                                        <t
-                                                    t-set="price"
-                                                    t-value="service.product_qty/line.price_total*(1-(service.reservation_id.discount or 0.0)*0.01) + price"
-                                                />
-                                                </t>
-                                            </t>
-                                        </t>
-                                </t>
-                                <t
-                                    t-if="not(not print_board_service and line.service_id.is_board_service)"
-                                >
-                                        <td name="td_name"><span
-                                            t-field="line.name"
-                                        /></td>
-                                        <td name="td_quantity" class="text-right">
-                                            <span t-field="line.product_uom_qty" />
-                                            <span
-                                            t-field="line.product_uom"
-                                            groups="uom.group_uom"
-                                        />
-                                        </td>
-
-                                        <td name="td_priceunit" class="text-right">
-                                                <span
-                                            t-esc="price"
-                                            t-options='{"widget": "monetary", "display_currency": folio.pricelist_id.currency_id}'
-                                        />
-                                        </td>
-                                        <td t-if="display_discount" class="text-right">
-                                            <span t-field="line.discount" />
-                                        </td>
-                                        <td name="td_taxes" class="text-right">
-                                            <span
-                                            t-esc="', '.join(map(lambda x: (x.description or x.name), line.tax_ids))"
-                                        />
-                                        </td>
-                                        <td
-                                        name="td_subtotal"
-                                        class="text-right o_price_total"
-                                    >
-                                            <span
-                                            t-esc="price*(1-(line.discount or 0.0)*0.01)* line.product_uom_qty"
-                                            groups="account.group_show_line_subtotals_tax_excluded"
-                                            t-options='{"widget": "monetary", "display_currency": folio.pricelist_id.currency_id}'
-                                        />
-                                            <span
-                                            t-esc="price *(1-(line.discount or 0.0)*0.01)* line.product_uom_qty"
-                                            groups="account.group_show_line_subtotals_tax_included"
-                                            t-options='{"widget": "monetary", "display_currency": folio.pricelist_id.currency_id}'
-                                        />
-                                        </td>
-                                </t>
-                            </t>
-                            <t t-if="line.display_type == 'line_section'">
+                             <t t-if="sale_line.display_type == 'line_section'">
                                 <td name="td_section_line" colspan="99">
-                                    <span t-field="line.name" />
+                                    <span t-field="sale_line.name" />
                                 </td>
-                                <t t-set="current_section" t-value="line" />
-                                <t t-set="current_subtotal" t-value="0" />
                             </t>
 
-                            <t t-if="line.display_type == 'line_note'">
+                            <t t-if="sale_line.display_type == 'line_note'">
                                 <td name="td_note_line" colspan="99">
-                                    <span t-field="line.name" />
+                                    <span t-field="sale_line.name" />
                                 </td>
                             </t>
-                        </tr>
 
-                        <t
-                            t-if="current_section and (line_last or folio.sale_line_ids[line_index+1].display_type == 'line_section')"
-                        >
-                            <tr class="is-subtotal text-right">
-                                <td name="td_section_subtotal" colspan="99">
-                                    <strong class="mr16">Subtotal</strong>
-                                    <span
-                                        t-esc="current_subtotal"
+
+                            <t t-if="not sale_line.display_type">
+                                 <td name="td_name">
+                                     <span t-field="sale_line.name" />
+                                 </td>
+                                 <td name="td_quantity" class="text-right">
+                                     <span t-field="sale_line.product_uom_qty" />
+                                 </td>
+                                <td name="td_priceunit" class="text-right">
+                                     <span
+                                        t-field="sale_line.price_unit"
                                         t-options='{"widget": "monetary", "display_currency": folio.pricelist_id.currency_id}'
                                     />
                                 </td>
-                            </tr>
-                        </t>
+                                <td t-if="display_discount" name="td_discount" class="text-right" >
+                                     <span t-field="sale_line.discount" />
+                                </td>
+                                <td name="td_taxes" class="text-right">
+                                    <span
+                                        t-esc="', '.join(map(lambda x: (x.description or x.name), sale_line.tax_ids))"
+                                    />
+                                </td>
+                                <td name="td_subtotal" class="text-right">
+                                     <t
+                                        t-esc="sale_line.price_total"
+                                        t-options='{"widget": "monetary", "display_currency": folio.pricelist_id.currency_id}'
+                                    />
+                                </td>
+                            </t>
+                        </tr>
                     </t>
                 </tbody>
             </table>


### PR DESCRIPTION
<ins>**BUG**</ins>: When a board service was configured to show included in the price of the reservation_line, the unit price was being miscalculated @ customer portal report.

_________________

<ins>**BEFORE FIX**</ins>:

https://user-images.githubusercontent.com/6873385/125443242-ca201571-8997-42b3-b5db-fe49ac86e50c.mp4

