### PR TITLE
[IMP]pms: pms.room name_get can also return amenities default_code

### DIFF
--- a/pms/models/pms_amenity.py
+++ b/pms/models/pms_amenity.py
@@ -40,3 +40,7 @@ class PmsRoomAmenity(models.Model):
     default_code = fields.Char(
         string="Internal Reference", help="Internal unique identifier of the amenity"
     )
+    is_add_code_room_name = fields.Boolean(
+        string="Add in room name",
+        help="True if the Internal Reference should appear in the display name of the rooms",
+    )

--- a/pms/models/pms_room.py
+++ b/pms/models/pms_room.py
@@ -103,6 +103,10 @@ class PmsRoom(models.Model):
             name = room.name
             if room.room_type_id:
                 name += " [%s]" % room.room_type_id.default_code
+            if room.room_amenity_ids:
+                for amenity in room.room_amenity_ids:
+                    if amenity.is_add_code_room_name:
+                        name += " %s" % amenity.default_code
             result.append((room.id, name))
         return result
 

--- a/pms/tests/test_pms_room.py
+++ b/pms/tests/test_pms_room.py
@@ -93,3 +93,128 @@ class TestPmsRoom(TestPms):
                 "The room should be created even if its name is equal "
                 "to another room, but that room not belongs to the same property."
             )
+
+    def test_display_name_room(self):
+        """
+        Check that the display_name field of a room is as expected.
+        ------------
+        A room is created and then it is checked that the display name
+        field of this is composed of:
+        room.name [room_type.default_code]
+        """
+        self.room1 = self.env["pms.room"].create(
+            {
+                "name": "Room 101",
+                "pms_property_id": self.pms_property1.id,
+                "room_type_id": self.room_type1.id,
+            }
+        )
+        expected_display_name = "%s [%s]" % (
+            self.room1.name,
+            self.room_type1.default_code,
+        )
+        self.assertEqual(
+            self.room1.display_name,
+            expected_display_name,
+            "The display name of the room is not as expected",
+        )
+
+    def test_display_name_room_with_amenity(self):
+        """
+        Check that the display_name field of a room with one amenity
+        is as expected.
+        ------------
+        A amenity is created with default code and with is_add_code_room_name
+        field as True. A room is created in which the amenity created before
+        is added in the room_amenity_ids field and then it is verified that
+        the display name field of this is composed of:
+        room.name [room_type.default_code] amenity.default_code
+        """
+        self.amenity_type1 = self.env["pms.amenity.type"].create(
+            {
+                "name": "Amenity Type 1",
+                "pms_property_ids": [(6, 0, [self.pms_property1.id])],
+            }
+        )
+        self.amenity1 = self.env["pms.amenity"].create(
+            {
+                "name": "Amenity 1",
+                "pms_amenity_type_id": self.amenity_type1.id,
+                "default_code": "A1",
+                "pms_property_ids": [(6, 0, [self.pms_property1.id])],
+                "is_add_code_room_name": True,
+            }
+        )
+        self.room1 = self.env["pms.room"].create(
+            {
+                "name": "Room 101",
+                "pms_property_id": self.pms_property1.id,
+                "room_type_id": self.room_type1.id,
+                "room_amenity_ids": [(6, 0, [self.amenity1.id])],
+            }
+        )
+        expected_display_name = "%s [%s] %s" % (
+            self.room1.name,
+            self.room_type1.default_code,
+            self.amenity1.default_code,
+        )
+        self.assertEqual(
+            self.room1.display_name,
+            expected_display_name,
+            "The display name of the room is not as expected",
+        )
+
+    def test_display_name_room_with_several_amenities(self):
+        """
+        Check that the display_name field of a room with several amenities
+        is as expected.
+        ------------
+        Two amenities are created with diferent default code and with is_add_code_room_name
+        field as True. A room is created in which the amenities created before are added in
+        the room_amenity_ids field and then it is verified that the display name field of this
+        is composed of:
+        room.name [room_type.default_code] amenity1.default_code amenity2.default_code
+        """
+        self.amenity_type1 = self.env["pms.amenity.type"].create(
+            {
+                "name": "Amenity Type 1",
+                "pms_property_ids": [(6, 0, [self.pms_property1.id])],
+            }
+        )
+        self.amenity1 = self.env["pms.amenity"].create(
+            {
+                "name": "Amenity 1",
+                "pms_amenity_type_id": self.amenity_type1.id,
+                "default_code": "A1",
+                "pms_property_ids": [(6, 0, [self.pms_property1.id])],
+                "is_add_code_room_name": True,
+            }
+        )
+        self.amenity2 = self.env["pms.amenity"].create(
+            {
+                "name": "Amenity 2",
+                "pms_amenity_type_id": self.amenity_type1.id,
+                "default_code": "B1",
+                "pms_property_ids": [(6, 0, [self.pms_property1.id])],
+                "is_add_code_room_name": True,
+            }
+        )
+        self.room1 = self.env["pms.room"].create(
+            {
+                "name": "Room 101",
+                "pms_property_id": self.pms_property1.id,
+                "room_type_id": self.room_type1.id,
+                "room_amenity_ids": [(6, 0, [self.amenity1.id, self.amenity2.id])],
+            }
+        )
+        expected_display_name = "%s [%s] %s %s" % (
+            self.room1.name,
+            self.room_type1.default_code,
+            self.amenity1.default_code,
+            self.amenity2.default_code,
+        )
+        self.assertEqual(
+            self.room1.display_name,
+            expected_display_name,
+            "The display name of the room is not as expected",
+        )

--- a/pms/views/pms_amenity_views.xml
+++ b/pms/views/pms_amenity_views.xml
@@ -27,6 +27,7 @@
                                     string="Amenity Type"
                                     domain="['|', ('pms_property_ids', '=', False), ('pms_property_ids', 'in', pms_property_ids)]"
                                 />
+                                <field name="is_add_code_room_name" />
                                 <!-- <field name="categ_id" select="1"
                                     domain="[('isamenitytype','=',True)]" /> -->
                             </group>
@@ -92,6 +93,8 @@
             <tree string="Room Amenities">
                 <field name="name" />
                 <field name="pms_amenity_type_id" select="1" />
+                <field name="default_code" />
+                <field name="is_add_code_room_name" />
                 <!-- <field name="list_price" string="Ty rate" invisible="1" /> -->
             </tree>
         </field>

--- a/pms/views/pms_room_views.xml
+++ b/pms/views/pms_room_views.xml
@@ -85,6 +85,9 @@
                                 <!-- <field name="description" colspan="2" string="Description Sales"/> -->
                             </group>
                         </page>
+                        <page string="Amenities">
+                            <field name="room_amenity_ids" />
+                        </page>
                     </notebook>
                     <group>
                         <field


### PR DESCRIPTION
The boolean is_add_code_room_name field has been added to pms.amenity. When adding an amenity with this field set to True in a room, the get_name() method will return (room.name [room_type.default_code] amenity.default_code). If the room has more amenities with the Boolean set to True, the default code for these will be added to the end of the string. 