### PR TITLE
[FIX]pms: allowed late checkin on checkout day

### DIFF
--- a/pms/models/pms_checkin_partner.py
+++ b/pms/models/pms_checkin_partner.py
@@ -652,7 +652,7 @@ class PmsCheckinPartner(models.Model):
         for record in self:
             if record.reservation_id.checkin > fields.Date.today():
                 raise ValidationError(_("It is not yet checkin day!"))
-            if record.reservation_id.checkout <= fields.Date.today():
+            if record.reservation_id.checkout < fields.Date.today():
                 raise ValidationError(_("Its too late to checkin"))
 
             if any(


### PR DESCRIPTION
The system allowed late check-in except when it coincided with the checkout day (typical case for single-night reservations), now it also allows check-in even if it is the same day of checkout