### PR TITLE
14.0 pms payments according journal type

### DIFF
--- a/pms/models/account_journal.py
+++ b/pms/models/account_journal.py
@@ -19,3 +19,7 @@ class AccountJournal(models.Model):
         help="The company for Account Jouarnal",
         check_pms_properties=True,
     )
+    allowed_pms_payments = fields.Boolean(
+        string="For manual payments",
+        help="Use to pay for reservations",
+    )

--- a/pms/models/account_payment.py
+++ b/pms/models/account_payment.py
@@ -1,88 +1,104 @@
 # Copyright 2017  Dario Lodeiros
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import _, fields, models
+from odoo import fields, models
 
 
 class AccountPayment(models.Model):
     _inherit = "account.payment"
 
     # Fields declaration
-    folio_id = fields.Many2one(
-        string="Folio Reference",
-        help="Folio in account payment",
+    folio_ids = fields.Many2many(
+        string="Folios",
         comodel_name="pms.folio",
+        ondelete="cascade",
+        relation="account_payment_folio_rel",
+        column1="payment_id",
+        column2="folio_id",
     )
+
+    def _prepare_move_line_default_vals(self, write_off_line_vals=None):
+        line_vals_list = super(AccountPayment, self)._prepare_move_line_default_vals(
+            write_off_line_vals
+        )
+        if self.folio_ids:
+            for line in line_vals_list:
+                line.update(
+                    {
+                        "folio_ids": [(6, 0, self.folio_ids.ids)],
+                    }
+                )
+        return line_vals_list
 
     # Business methods
 
-    def modify(self):
-        self.cancel()
-        vals = {
-            "journal_id": self.journal_id,
-            "partner_id": self.partner_id,
-            "amount": self.amount,
-            "payment_date": self.payment_date,
-            "communication": self.communication,
-            "state": "draft",
-        }
-        self.update(vals)
-        self.with_context({"ignore_notification_post": True}).post()
-        self._compute_folio_amount()
-        if self.folio_id:
-            msg = _("Payment %s modified: \n") % (self.communication)
-            if self.save_amount and self.save_amount != self.amount:
-                msg += _("Amount from %s to %s %s \n") % (
-                    self.save_amount,
-                    self.amount,
-                    self.currency_id.symbol,
-                )
-            if self.save_date and self.save_date != self.payment_date:
-                msg += _("Date from %s to %s \n") % (self.save_date, self.payment_date)
-            if self.save_journal_id and self.save_journal_id != self.journal_id.id:
-                msg += _("Journal from %s to %s") % (
-                    self.env["account.journal"].browse(self.save_journal_id).name,
-                    self.journal_id.name,
-                )
-            self.folio_id.message_post(subject=_("Payment"), body=msg)
+    # def modify(self):
+    #     self.cancel()
+    #     vals = {
+    #         "journal_id": self.journal_id,
+    #         "partner_id": self.partner_id,
+    #         "amount": self.amount,
+    #         "payment_date": self.payment_date,
+    #         "communication": self.communication,
+    #         "state": "draft",
+    #     }
+    #     self.update(vals)
+    #     self.with_context({"ignore_notification_post": True}).post()
+    #     self._compute_folio_amount()
+    #     if self.folio_id:
+    #         msg = _("Payment %s modified: \n") % (self.communication)
+    #         if self.save_amount and self.save_amount != self.amount:
+    #             msg += _("Amount from %s to %s %s \n") % (
+    #                 self.save_amount,
+    #                 self.amount,
+    #                 self.currency_id.symbol,
+    #             )
+    #         if self.save_date and self.save_date != self.payment_date:
+    #             msg += _("Date from %s to %s \n") % (self.save_date, self.payment_date)
+    #         if self.save_journal_id and self.save_journal_id != self.journal_id.id:
+    #             msg += _("Journal from %s to %s") % (
+    #                 self.env["account.journal"].browse(self.save_journal_id).name,
+    #                 self.journal_id.name,
+    #             )
+    #         self.folio_id.message_post(subject=_("Payment"), body=msg)
 
-    def delete(self):
-        msg = False
-        if self.folio_id:
-            msg = _("Deleted payment: %s %s ") % (self.amount, self.currency_id.symbol)
-        self.cancel()
-        self.move_name = ""
-        self.unlink()
-        if msg:
-            self.folio_id.message_post(subject=_("Payment Deleted"), body=msg)
+    # def delete(self):
+    #     msg = False
+    #     if self.folio_id:
+    #         msg = _("Deleted payment: %s %s ") % (self.amount, self.currency_id.symbol)
+    #     self.cancel()
+    #     self.move_name = ""
+    #     self.unlink()
+    #     if msg:
+    #         self.folio_id.message_post(subject=_("Payment Deleted"), body=msg)
 
-    def post(self):
-        rec = super(AccountPayment, self).post()
-        if rec and not self._context.get("ignore_notification_post", False):
-            for pay in self:
-                if pay.folio_id:
-                    msg = _(
-                        "Payment of %s %s registered from %s \
-                            using %s payment method"
-                    ) % (
-                        pay.amount,
-                        pay.currency_id.symbol,
-                        pay.communication,
-                        pay.journal_id.name,
-                    )
-                    pay.folio_id.message_post(subject=_("Payment"), body=msg)
+    # def post(self):
+    #     rec = super(AccountPayment, self).post()
+    #     if rec and not self._context.get("ignore_notification_post", False):
+    #         for pay in self:
+    #             if pay.folio_id:
+    #                 msg = _(
+    #                     "Payment of %s %s registered from %s \
+    #                         using %s payment method"
+    #                 ) % (
+    #                     pay.amount,
+    #                     pay.currency_id.symbol,
+    #                     pay.communication,
+    #                     pay.journal_id.name,
+    #                 )
+    #                 pay.folio_id.message_post(subject=_("Payment"), body=msg)
 
-    def modify_payment(self):
-        self.ensure_one()
-        view_form_id = self.env.ref("pms.account_payment_view_form_folio").id
-        # moves = self.mapped('move_ids.id')
-        return {
-            "name": _("Payment"),
-            "view_type": "form",
-            "views": [(view_form_id, "form")],
-            "view_mode": "tree,form",
-            "res_model": "account.payment",
-            "target": "new",
-            "init_mode": "edit",
-            "type": "ir.actions.act_window",
-            "res_id": self.id,
-        }
+    # def modify_payment(self):
+    #     self.ensure_one()
+    #     view_form_id = self.env.ref("pms.account_payment_view_form_folio").id
+    #     # moves = self.mapped('move_ids.id')
+    #     return {
+    #         "name": _("Payment"),
+    #         "view_type": "form",
+    #         "views": [(view_form_id, "form")],
+    #         "view_mode": "tree,form",
+    #         "res_model": "account.payment",
+    #         "target": "new",
+    #         "init_mode": "edit",
+    #         "type": "ir.actions.act_window",
+    #         "res_id": self.id,
+    #     }

--- a/pms/models/payment_transaction.py
+++ b/pms/models/payment_transaction.py
@@ -1,0 +1,22 @@
+from odoo import fields, models
+
+
+class PaymentTransaction(models.Model):
+    _name = "payment.transaction"
+
+    folio_ids = fields.Many2many(
+        string="Folios",
+        comodel_name="pms.folio",
+        ondelete="cascade",
+        relation="account_bank_statement_folio_rel",
+        column1="account_journal_id",
+        column2="folio_id",
+    )
+
+    def _create_payment(self, add_payment_vals=False):
+        self.ensure_one()
+        if not add_payment_vals:
+            add_payment_vals = {}
+        if self.folio_ids:
+            add_payment_vals["folio_ids"] = [(6, 0, self.folio_ids.ids)]
+        return super(PaymentTransaction, self)._create_payment(add_payment_vals)

--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -1502,16 +1502,16 @@ class PmsFolio(models.Model):
         services=False,
         partner=False,
         date=False,
-        type=False,
+        pay_type=False,
     ):
         """
         create folio payment
         type: set cash to use statement or bank to use account.payment,
         by default, use the journal type
         """
-        if not type:
-            type = journal.type
-        if type == "cash":
+        if not pay_type:
+            pay_type = journal.type
+        if pay_type == "cash":
             line = self._get_statement_line_vals(
                 journal=journal,
                 receivable_account=receivable_account,

--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -408,6 +408,7 @@ class PmsProperty(models.Model):
         self.ensure_one()
         payment_methods = self.env["account.journal"].search(
             [
+                ("allowed_pms_payments", "=", True),
                 "&",
                 ("type", "in", ["cash", "bank"]),
                 "|",

--- a/pms/tests/test_pms_folio.py
+++ b/pms/tests/test_pms_folio.py
@@ -47,6 +47,13 @@ class TestPmsFolio(TestPms):
                 "capacity": 2,
             }
         )
+        # make current journals payable
+        journals = self.env["account.journal"].search(
+            [
+                ("type", "in", ["bank", "cash"]),
+            ]
+        )
+        journals.allowed_pms_payments = True
 
     def create_sale_channel_scenario(self):
         """

--- a/pms/tests/test_pms_payment.py
+++ b/pms/tests/test_pms_payment.py
@@ -8,3 +8,31 @@ freeze_time("2000-02-02")
 class TestPmsPayment(SavepointCase):
     def setUp(self):
         super(TestPmsPayment, self).setUp()
+
+    # TODO: Test allowed manual payment
+    # create a journal with allowed_pms_payments = True and
+    # check that the _get_payment_methods property method return it
+
+    # TODO: Test not allowed manual payment
+    # create a journal without allowed_pms_payments = True and
+    # check that the _get_payment_methods property method dont return it
+
+    # TODO: Test default account payment create
+    # create a bank journal, a reservation, pay the reservation
+    # with do_payment method without pay_type parameter
+    # and check that account payment was created
+
+    # TODO: Test default statement line create
+    # create a cash journal, a reservation, pay the reservation
+    # with do_payment method without pay_type parameter
+    # and check that statement line was created
+
+    # TODO: Test set pay_type cash, statement line create
+    # create a bank journal, a reservation, pay the reservation
+    # with do_payment method with 'cash' pay_type parameter
+    # and check that statement line was created
+
+    # TODO: Test set pay_type bank, account payment create
+    # create a cash journal, a reservation, pay the reservation
+    # with do_payment method with 'bank' pay_type parameter
+    # and check that account payment was created

--- a/pms/views/account_journal_views.xml
+++ b/pms/views/account_journal_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="pms_property_ids" widget="many2many_tags" />
+                <field name="allowed_pms_payments" />
             </xpath>
         </field>
     </record>

--- a/pms/views/account_payment_views.xml
+++ b/pms/views/account_payment_views.xml
@@ -5,7 +5,7 @@
         <field name="inherit_id" ref="account.view_account_payment_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='date']" position="after">
-                <field name="folio_id" />
+                <field name="folio_ids" />
             </xpath>
         </field>
     </record>

--- a/pms/views/pms_folio_views.xml
+++ b/pms/views/pms_folio_views.xml
@@ -533,6 +533,40 @@
                                 />
                             </group>
                         </page>
+                        <page string="Payments">
+                            <separator string="Cash" colspan="4" />
+                            <field name="statement_line_ids" nolabel="1">
+                                <tree>
+                                    <field name="journal_id" string="Payment Mode" />
+                                    <field name="date" />
+                                    <field name="amount" />
+                                    <field name="partner_id" invisible="1" />
+                                    <field name="state" invisible="1" />
+                                </tree>
+                            </field>
+                            <separator string="Bank" colspan="4" />
+                            <field name="payment_ids" nolabel="1">
+                                <tree>
+                                    <field name="journal_id" string="Payment Mode" />
+                                    <field name="date" />
+                                    <field name="amount" />
+                                    <field name="partner_id" invisible="1" />
+                                    <field name="state" invisible="1" />
+                                </tree>
+                            </field>
+                            <!-- REVIEW: transations has a payment related -->
+                            <!-- <field
+                                name="transaction_ids"
+                                nolabel="1"
+                            >
+                                <tree>
+                                    <field name="journal_id" />
+                                    <field name="date" />
+                                    <field name="amount" />
+                                    <field name="partner_id" />
+                                </tree>
+                            </field> -->
+                        </page>
                         <page string="Other data">
                             <group>
                                 <field name="user_id" />


### PR DESCRIPTION
With this change the pms can pay folios with statement lines, account payments or payment transactions.
The system use by default statement line for cash type journals, account payments for bank type journals (transactions are created in website payment adquirer). You can set the type of payment with the pay_type parameter on do_payment folio method.

This PR, also, add a folio payment check field on journal to filter the bank/cash allowed payment journals (regardless of what is used account.payment or statements).
