### PR TITLE
[14.0] pms: PMS Property in analytic account and reconciliation widget

### DIFF
--- a/pms/__manifest__.py
+++ b/pms/__manifest__.py
@@ -26,6 +26,7 @@
         "partner_contact_gender",
         "partner_contact_birthdate",
         "partner_contact_nationality",
+        "account_reconciliation_widget",
         # "partner_identification_unique_by_category",
     ],
     "data": [
@@ -95,6 +96,8 @@
         "report/proforma_report.xml",
         "views/account_portal_templates.xml",
         "views/payment_acquirer_views.xml",
+        "views/account_analytic_distribution_view.xml",
+        "views/account_analytic_line_view.xml",
     ],
     "demo": [
         "demo/pms_master_data.xml",
@@ -104,6 +107,7 @@
     "qweb": [
         "static/src/xml/pms_base_templates.xml",
         "static/src/xml/reservation_group_button_views.xml",
+        "static/src/xml/account_reconciliation.xml",
     ],
     "pre_init_hook": "pre_init_hook",
 }

--- a/pms/models/__init__.py
+++ b/pms/models/__init__.py
@@ -49,3 +49,4 @@ from . import payment_transaction
 from . import pms_team_member
 from . import ir_pms_property
 from . import payment_acquirer
+from . import account_analytic_line

--- a/pms/models/account_analytic_line.py
+++ b/pms/models/account_analytic_line.py
@@ -1,0 +1,33 @@
+from odoo import api, fields, models
+
+
+class AccountAnalyticLine(models.Model):
+    _inherit = "account.analytic.line"
+    _check_pms_properties_auto = True
+
+    pms_property_id = fields.Many2one(
+        name="Property",
+        comodel_name="pms.property",
+        compute="_compute_pms_property_id",
+        store=True,
+        readonly=False,
+        check_pms_properties=True,
+    )
+
+    @api.depends("move_id")
+    def _compute_pms_property_id(self):
+        for rec in self:
+            if rec.move_id and rec.move_id.pms_property_id:
+                rec.pms_property_id = rec.move_id.pms_property_id
+            elif not rec.pms_property_id:
+                rec.pms_property_id = False
+
+
+class AccountAnalyticDistribution(models.Model):
+    _inherit = "account.analytic.distribution"
+
+    pms_property_id = fields.Many2one(
+        name="Property",
+        comodel_name="pms.property",
+        check_pms_properties=True,
+    )

--- a/pms/models/account_bank_statement_line.py
+++ b/pms/models/account_bank_statement_line.py
@@ -78,3 +78,17 @@ class AccountBankStatementLine(models.Model):
         for record in to_reconcile_move_lines:
             payment_move_line = record if record.balance == self.amount else False
         return payment_move_line
+
+    def _create_counterpart_and_new_aml(
+        self, counterpart_moves, counterpart_aml_dicts, new_aml_dicts
+    ):
+        for aml_dict in new_aml_dicts:
+            if aml_dict.get("pms_property_id"):
+                self.move_id.pms_property_id = False
+                break
+        return super(
+            AccountBankStatementLine,
+            self.with_context(no_recompute_move_pms_property=True),
+        )._create_counterpart_and_new_aml(
+            counterpart_moves, counterpart_aml_dicts, new_aml_dicts
+        )

--- a/pms/models/account_move.py
+++ b/pms/models/account_move.py
@@ -63,9 +63,13 @@ class AccountMove(models.Model):
     @api.depends("journal_id", "folio_ids")
     def _compute_pms_property_id(self):
         for move in self:
-            if move.folio_ids:
+            if self.env.context.get("force_pms_property"):
+                move.pms_property_id = self.env.context["force_pms_property"]
+            elif move.folio_ids:
                 move.pms_property_id = move.folio_ids.mapped("pms_property_id")
-            elif len(move.journal_id.mapped("pms_property_ids")) == 1:
+            elif len(
+                move.journal_id.mapped("pms_property_ids")
+            ) == 1 and not self.env.context.get("no_recompute_move_pms_property"):
                 move.pms_property_id = move.journal_id.mapped("pms_property_ids")[0]
             elif not move.journal_id.pms_property_ids:
                 move.pms_property_id = False

--- a/pms/models/account_move_line.py
+++ b/pms/models/account_move_line.py
@@ -109,3 +109,20 @@ class AccountMoveLine(models.Model):
             agencies = line.mapped("folio_line_ids.origin_agency_id")
             if agencies:
                 line.origin_agency_id = agencies[0]
+
+    def _prepare_analytic_distribution_line(self, distribution):
+        vals = super()._prepare_analytic_distribution_line(distribution)
+        if distribution.pms_property_id:
+            vals["pms_property_id"] = distribution.pms_property_id.id
+        return vals
+
+    def _prepare_analytic_line(self):
+        result = super()._prepare_analytic_line()
+        for move_line in result:
+            move = self.browse(move_line["move_id"])
+            if move.pms_property_id or move.move_id.pms_property_id:
+                move_line["pms_property_id"] = (
+                    move.pms_property_id.id
+                    or move.move_id.pms_property_id.pms_property_id.id
+                )
+        return result

--- a/pms/readme/CONTRIBUTORS.rst
+++ b/pms/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
   * Sara Lago
   * Brais Abeijon
   * Miguel Padin
+* Omar Castiñeira <omar@comunitea.com>

--- a/pms/static/src/js/reconciliation_widget.js
+++ b/pms/static/src/js/reconciliation_widget.js
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 Comunitea.
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+*/
+odoo.define("account_reconciliation_widget_inherit", function (require) {
+    "use strict";
+
+    var core = require("web.core");
+    var relational_fields = require("web.relational_fields");
+    var ReconciliationRenderer = require("account.ReconciliationRenderer");
+    var ReconciliationModel = require("account.ReconciliationModel");
+    var _t = core._t;
+
+    ReconciliationModel.StatementModel.include({
+        init: function (parent, options) {
+            this._super(parent, options);
+            this.extra_field_names = ["pms_property_id"];
+            this.extra_fields = [
+                {
+                    relation: "pms.property",
+                    type: "many2one",
+                    name: "pms_property_id",
+                },
+            ];
+            this.extra_fieldInfo = {
+                pms_property_id: {string: _t("Property")},
+            };
+            this.quickCreateFields = this.quickCreateFields.concat(
+                this.extra_field_names
+            );
+        },
+
+        makeRecord: function (model, fields, fieldInfo) {
+            if (model === "account.bank.statement.line") {
+                var new_fields = fields.concat(this.extra_fields);
+                _.extend(fieldInfo, this.extra_fieldInfo);
+            }
+            return this._super(model, new_fields, fieldInfo);
+        },
+
+        _formatToProcessReconciliation: function (line, prop) {
+            var result = this._super(line, prop);
+            if (prop.pms_property_id) result.pms_property_id = prop.pms_property_id.id;
+            return result;
+        },
+
+        _formatQuickCreate: function (line, values) {
+            var prop = this._super(line, values);
+            prop.pms_property_id = "";
+            return prop;
+        },
+    });
+
+    ReconciliationRenderer.LineRenderer.include({
+        _renderCreate: function (state) {
+            return Promise.all([this._super(state), this._makePmsPropertyRecord()]);
+        },
+
+        _makePmsPropertyRecord: function () {
+            const field = {
+                type: "many2one",
+                name: "pms_property_id",
+                relation: "pms.property",
+            };
+            return this.model
+                .makeRecord("account.bank.statement.line", [field], {
+                    pms_property_id: {},
+                })
+                .then((recordID) => {
+                    this.fields.pms_property_id = new relational_fields.FieldMany2One(
+                        this,
+                        "pms_property_id",
+                        this.model.get(recordID),
+                        {
+                            mode: "edit",
+                        }
+                    );
+                    this.fields.pms_property_id.appendTo(
+                        this.$(".create_pms_property_id .o_td_field")
+                    );
+                });
+        },
+    });
+});

--- a/pms/static/src/xml/account_reconciliation.xml
+++ b/pms/static/src/xml/account_reconciliation.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates>
+
+  <t t-extend="reconciliation.line.create">
+
+    <t t-jquery="tr[class='create_analytic_tag_ids']" t-operation="append">
+      <tr class="create_pms_property_id">
+        <td class="o_td_label"><label class="o_form_label">Property</label></td>
+        <td class="o_td_field" />
+      </tr>
+    </t>
+
+  </t>
+
+</templates>

--- a/pms/views/account_analytic_distribution_view.xml
+++ b/pms/views/account_analytic_distribution_view.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+        <record
+        id="account_analytic_tag_form_view_add_distribution_tags"
+        model="ir.ui.view"
+    >
+            <field name="name">account.analytic.tag.form.add_distribution_tags</field>
+            <field name="model">account.analytic.tag</field>
+            <field name="inherit_id" ref="analytic.account_analytic_tag_form_view" />
+            <field name="arch" type="xml">
+                <xpath
+                expr="//field[@name='analytic_distribution_ids']/tree/field[@name='account_id']"
+                position="after"
+            >
+                    <field name="pms_property_id" />
+                </xpath>
+            </field>
+        </record>
+
+</odoo>

--- a/pms/views/account_analytic_line_view.xml
+++ b/pms/views/account_analytic_line_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+        <record id="view_account_analytic_line_tree_inherit_account" model="ir.ui.view">
+            <field name="name">account.analytic.line.tree.inherit.account</field>
+            <field name="model">account.analytic.line</field>
+            <field
+            name="inherit_id"
+            ref="account.view_account_analytic_line_tree_inherit_account"
+        />
+            <field name="arch" type="xml">
+                <field name="product_id" position="after">
+                    <field name="pms_property_id" optional="show" />
+                </field>
+            </field>
+        </record>
+
+</odoo>

--- a/pms/views/webclient_templates.xml
+++ b/pms/views/webclient_templates.xml
@@ -16,6 +16,10 @@
                     type="text/javascript"
                     src="/pms/static/src/js/pms_list_controller.js"
                 />
+                <script
+                    type="text/javascript"
+                    src="/pms/static/src/js/reconciliation_widget.js"
+                />
             </xpath>
         </template>
     </data>


### PR DESCRIPTION
Hi,

This improvement adds:
- The possibility of change the pms property by default in manual moves within reconciliation widget. Sometimes, bank lines could not be of journal's pms property.
- The possibility of set pms property in analytic lines. If analytic line is created from account move line, it pulls the pms property from related account move line.
- The possibility of add pms property on analytic distribution lines and therefore allow to separate expenses/incomes in several pms properties analytically.
- I needed pass in context a foced property parameter for setting from reconciliation widget's manually set. This paramater could be user in other functionalities in the future, like the default 'force_company'

On the other hand, I tried to add the "account-reconcile" OCA's repository to "oca_dependencies.txt" file by the new dependency "account_reconciliation_widget" but if I do that, it conflicts with https://github.com/OCA/pms/pull/1 that adds connector dependency and we can't apply the merge in deployment.