### PR TITLE
[FIX] pms: Adding missing super statment on _compute_name

### DIFF
--- a/pms/models/account_move_line.py
+++ b/pms/models/account_move_line.py
@@ -57,8 +57,9 @@ class AccountMoveLine(models.Model):
     )
     move_id = fields.Many2one(check_pms_properties=True)
 
-    @api.depends("quantity")
+    @api.depends('move_id.payment_reference', "quantity")
     def _compute_name(self):
+        res = super()._compute_name()
         for record in self:
             if record.folio_line_ids and not record.name_changed_by_user:
                 record.name_changed_by_user = False
@@ -70,6 +71,7 @@ class AccountMoveLine(models.Model):
                     record.folio_line_ids.service_line_ids,
                     qty=record.quantity,
                 )
+        return res
 
     @api.depends("move_id")
     def _compute_pms_property_id(self):


### PR DESCRIPTION
Odoo introduced following commit:
https://github.com/odoo/odoo/commit/1dcd071b27779e7d6d8f536c7dce7002d27212ba

Where converts the name field on account.move.line model into a computed field, this leads on a conflict since pms module make the same, but now it's overwriting the original funciton made by odoo so this it's addind the mising super statement to compleate inheritance