### PR TITLE
[14.][FIX] pms: Error with manual reconciliations

### DIFF
--- a/pms/static/src/js/reconciliation_widget.js
+++ b/pms/static/src/js/reconciliation_widget.js
@@ -32,10 +32,10 @@ odoo.define("account_reconciliation_widget_inherit", function (require) {
 
         makeRecord: function (model, fields, fieldInfo) {
             if (model === "account.bank.statement.line") {
-                var new_fields = fields.concat(this.extra_fields);
+                var fields = fields.concat(this.extra_fields);
                 _.extend(fieldInfo, this.extra_fieldInfo);
             }
-            return this._super(model, new_fields, fieldInfo);
+            return this._super(model, fields, fieldInfo);
         },
 
         _formatToProcessReconciliation: function (line, prop) {


### PR DESCRIPTION
Hi,

Since my last PR (pms property in reconciliation widget) is failing the manual reconciliation of account.move.line because it uses the same widget from other model. Now it's fixed.

Regards