### PR TITLE
[14.0] restore reservation calendar view

### DIFF
--- a/pms/__manifest__.py
+++ b/pms/__manifest__.py
@@ -29,6 +29,7 @@
         "account_reconciliation_widget",
         # "partner_identification_unique_by_category",
         "queue_job",
+        "web_timeline",
     ],
     "data": [
         "security/pms_security.xml",

--- a/pms/views/pms_reservation_views.xml
+++ b/pms/views/pms_reservation_views.xml
@@ -3,7 +3,7 @@
     <record model="ir.actions.act_window" id="open_pms_reservation_form_tree_all">
         <field name="name">Reservation</field>
         <field name="res_model">pms.reservation</field>
-        <field name="view_mode">tree,form,graph,pivot,calendar</field>
+        <field name="view_mode">tree,form,graph,pivot,calendar,timeline</field>
     </record>
 
     <record model="ir.ui.view" id="pms_reservation_view_form">
@@ -767,6 +767,31 @@
                 <field name="partner_id" avatar_field="image_128" />
                 <field name="rooms" />
             </calendar>
+        </field>
+    </record>
+
+     <record id="pms_reservation_view_timeline" model="ir.ui.view">
+        <field name="name">pms.reservation.view.timeline</field>
+        <field name="model">pms.reservation</field>
+        <field name="arch" type="xml">
+            <timeline
+                string="Reservations"
+                date_start="checkin_datetime"
+                date_stop="checkout_datetime"
+                default_group_by="preferred_room_id"
+                stack="True"
+                mode="month"
+                event_open_popup="False"
+            >
+                <field name="name" />
+                <field name="partner_id" />
+                <field name="preferred_room_id" />
+                <templates>
+                    <div t-name="timeline-item">
+                        <div t-esc="record.name" />
+                    </div>
+                </templates>
+            </timeline>
         </field>
     </record>
 

--- a/pms/views/pms_reservation_views.xml
+++ b/pms/views/pms_reservation_views.xml
@@ -3,8 +3,9 @@
     <record model="ir.actions.act_window" id="open_pms_reservation_form_tree_all">
         <field name="name">Reservation</field>
         <field name="res_model">pms.reservation</field>
-        <field name="view_mode">tree,form,graph,pivot</field>
+        <field name="view_mode">tree,form,graph,pivot,calendar</field>
     </record>
+
     <record model="ir.ui.view" id="pms_reservation_view_form">
         <field name="name">pms.reservation.form</field>
         <field name="model">pms.reservation</field>
@@ -748,18 +749,18 @@
     </record>
 
     <!-- Calendar -->
-    <!-- <record id="pms_reservation_view_calendar" model="ir.ui.view">
+     <record id="pms_reservation_view_calendar" model="ir.ui.view">
         <field name="name">pms.reservation.view.calendar</field>
         <field name="model">pms.reservation</field>
         <field name="arch" type="xml">
             <calendar
-                date_start="checkin_datetime"
-                date_stop="checkout_datetime"
+                date_start="checkin"
+                date_stop="checkout"
                 string="Reservations"
                 quick_add="False"
                 mode="month"
                 color="room_type_id"
-                scales="month,year"
+                scales="week,month,year"
             >
                 <field name="room_type_id" filters="1" />
                 <field name="preferred_room_id" filters="1" />
@@ -767,7 +768,8 @@
                 <field name="rooms" />
             </calendar>
         </field>
-    </record> -->
+    </record>
+
     <record model="ir.ui.view" id="pms_reservation_view_tree">
         <field name="name">pms.reservation.tree</field>
         <field name="model">pms.reservation</field>


### PR DESCRIPTION
This PR "recovers" the calendar view on booking. I understand the view was commented out because it was based on `checkin_datetime` and `checkout_datetime`. Those fields are computed, not stored and therefore not searchable. This lead to errors in the logs.

One way to fix this is to add a search functions on fields : 

```py
checkin_datetime = fields.Datetime(
    ...
    search="_search_checkin_datetime",
)
checkout_datetime = fields.Datetime(
    ...
    search="_search_checkout_datetime",
)

def _search_checkin_datetime(self, operator, value):
    return [("checkin", operator, value)]

def _search_checkout_datetime(self, operator, value):
    return [("checkout", operator, value)]
```

I did not choose this option because
- the search functions need to take into account the user time zone (possible but complicated)
- the week view is not readable with datetimes

![Screenshot 2023-06-21 at 14 43 48](https://github.com/OCA/pms/assets/3082119/2b16e4e2-1d68-4d25-954d-ec5739473130)

I resorted to base the calendar view on `checkin` and `checkout` instead.