### PR TITLE
[ADD] pms: add room and room type to search view

### DIFF
--- a/pms/views/pms_reservation_views.xml
+++ b/pms/views/pms_reservation_views.xml
@@ -914,6 +914,8 @@
                         ('mobile', 'ilike', self),
                     ]"
                 />
+                <field name="preferred_room_id" />
+                <field name="room_type_id" />
                 <field name="partner_id" />
                 <field name="folio_id" />
                 <field name="agency_id" />


### PR DESCRIPTION
Adds room to the quick filters. It allows the user to quickly see wether a specific room or room type is used at a specific time (more relevant useful w/ calendar view). 