### PR TITLE
[FIX] pms: set possible_existing_customer_ids to false

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -1371,14 +1371,13 @@ class PmsFolio(models.Model):
     @api.depends("email", "mobile", "partner_name")
     def _compute_possible_existing_customer_ids(self):
         for record in self:
+            record.possible_existing_customer_ids = False
             if record.partner_name:
                 possible_customer = self._apply_possible_existing_customer_ids(
                     record.email, record.mobile, record.partner_id
                 )
                 if possible_customer:
                     record.possible_existing_customer_ids = possible_customer
-                else:
-                    record.possible_existing_customer_ids = False
 
     @api.depends("reservation_ids", "reservation_ids.checkin")
     def _compute_first_checkin(self):

--- a/pms/tests/test_pms_folio.py
+++ b/pms/tests/test_pms_folio.py
@@ -4,7 +4,7 @@ from freezegun import freeze_time
 
 from odoo import fields
 from odoo.exceptions import ValidationError
-
+from odoo.tests import Form
 from .common import TestPms
 
 
@@ -1536,3 +1536,7 @@ class TestPmsFolio(TestPms):
             "sale_channel_origin_id of reservations that coincided "
             "with sale_channel_origin_id of folio de should be updated",
         )
+
+    def test_pms_folio_form_creation(self):
+        folio_form = Form(self.env["pms.folio"])
+        self.assertFalse(folio_form.possible_existing_customer_ids)


### PR DESCRIPTION
When creating a new folio from the interface, odoo fails to assign possible_existing_customer_ids to the record and crashes.
Setting it to False for the cas when there are no partner_name 
nor possible_customer fixes the issue.

---

The commit fixes the issue but since there are no way to add reservation from the folio, it raises the question
- should it be possible to even create a folio w/o the booking engine ?
- when are the folio in state quotation ?