### PR TITLE
[FIX] pms: fix NumRoomsSelectionModel.booking_engine_id

### DIFF
--- a/pms/wizards/pms_booking_engine.py
+++ b/pms/wizards/pms_booking_engine.py
@@ -292,7 +292,7 @@ class NumRoomsSelectionModel(models.TransientModel):
     room_type_id = fields.Char()
     booking_engine_id = fields.One2many(
         comodel_name="pms.folio.availability.wizard",
-        inverse_name="id",
+        inverse_name="num_rooms_selected",
     )
 
 


### PR DESCRIPTION
Inverse relation is defined here : 

https://github.com/OCA/pms/blob/01d869b4697e04d0fa22429a1c511c5b5dbb76b6/pms/wizards/pms_booking_engine.py#L331-L339

in AvailabilityWizard (booking engine lines)