### PR TITLE
[IMP]pms: folio_sale_line compare float value round in invoiced folios

### DIFF
--- a/pms/models/folio_sale_line.py
+++ b/pms/models/folio_sale_line.py
@@ -991,9 +991,14 @@ class FolioSaleLine(models.Model):
                         )
                     )
                 # We check that dont modified the protected fields in locked folios
+                # if field is float, we need to round it to compare with the original value
                 if self.filtered(
                     lambda l: any(
-                        values.get(field.name) != getattr(l, field.name)
+                        round(values.get(field.name), 2)
+                        != round(getattr(l, field.name), 2)
+                        if isinstance(values.get(field.name), float)
+                        and isinstance(getattr(l, field.name), float)
+                        else values.get(field.name) != getattr(l, field.name)
                         for field in fields_modified
                     )
                 ):


### PR DESCRIPTION
In the modifications of invoiced records, to ensure that a value like units (which is locked by the invoice) is not being modified, it's better to use a round function to avoid issues in the comparison