### PR TITLE
[IMP]pms: allowd journal filters by room

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -2082,7 +2082,10 @@ class PmsFolio(models.Model):
         (making sure to call super() to establish a clean extension chain).
         """
         self.ensure_one()
-        journal = self.pms_property_id._get_folio_default_journal(partner_invoice_id)
+        journal = self.pms_property_id._get_folio_default_journal(
+            partner_invoice_id=partner_invoice_id,
+            room_ids=self.reservation_ids.mapped("reservation_line_ids.room_id.id"),
+        )
         if not journal:
             journal = (
                 self.env["account.move"]

--- a/pms/views/account_journal_views.xml
+++ b/pms/views/account_journal_views.xml
@@ -6,6 +6,12 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="pms_property_ids" widget="many2many_tags" />
+                <field name="allowed_room_ids" invisible="1" />
+                <field
+                    name="room_filter_ids"
+                    string="Room Types"
+                    widget="many2many_tags"
+                />
                 <field
                     name="allowed_pms_payments"
                     attrs="{'invisible':[('type','not in',('bank', 'cash'))]}"

--- a/pms/wizards/folio_make_invoice_advance.py
+++ b/pms/wizards/folio_make_invoice_advance.py
@@ -160,7 +160,10 @@ class FolioAdvancePaymentInv(models.TransientModel):
             "ref": order.name,
             "move_type": "out_invoice",
             "journal_id": order.pms_property_id._get_folio_default_journal(
-                partner_id
+                partner_invoice_id=partner_id,
+                room_ids=order.mapped(
+                    "reservation_ids.reservation_line_ids.room_id.id"
+                ),
             ).id,
             "invoice_origin": order.name,
             "invoice_user_id": order.user_id.id,

--- a/pms/wizards/wizard_payment_folio.py
+++ b/pms/wizards/wizard_payment_folio.py
@@ -46,7 +46,11 @@ class WizardPaymentFolio(models.TransientModel):
         self.ensure_one()
         journal_ids = False
         if self.folio_id:
-            journal_ids = self.folio_id.pms_property_id._get_payment_methods().ids
+            journal_ids = self.folio_id.pms_property_id._get_payment_methods(
+                room_ids=self.folio_id.mapped(
+                    "reservation_ids.reservation_line_ids.room_id.id"
+                ),
+            ).ids
         self.allowed_method_ids = journal_ids
 
     def button_payment(self):


### PR DESCRIPTION
This pull request introduces several changes to the `pms` module, primarily focusing on adding room filtering capabilities to various models and methods. The most important changes include the addition of new fields to the `AccountJournal` model, updates to methods to accommodate room filtering, and modifications to the XML views to include the new fields.

### Model Updates:
* Added `allowed_room_ids` and `room_filter_ids` fields to the `AccountJournal` model to filter rooms in reservations (`pms/models/account_journal.py`).

### Method Enhancements:
* Updated `_compute_allowed_room_ids` method to compute allowed room IDs based on property IDs (`pms/models/account_journal.py`).
* Modified `_prepare_invoice` method to pass room IDs when getting the default journal (`pms/models/pms_folio.py`).
* Enhanced `_get_payment_methods` method to filter payment methods by room IDs (`pms/models/pms_property.py`). [[1]](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bL572-R578) [[2]](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bR594-R598)
* Updated `_get_folio_default_journal` method to filter journals by room IDs for both simplified and normal invoices (`pms/models/pms_property.py`). [[1]](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bL894-R904) [[2]](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bR913-R962)

### View Modifications:
* Added `allowed_room_ids` and `room_filter_ids` fields to the account journal form view (`pms/views/account_journal_views.xml`).