### PR TITLE
[ADD]pms: Self billing folios configuration

### DIFF
--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -895,6 +895,11 @@ class PmsProperty(models.Model):
         self.ensure_one()
         partner = self.env["res.partner"].browse(partner_invoice_id)
         if (
+            self.company_id.partner_id.id == partner.id
+            and self.company_id.self_billed_journal_id
+        ):
+            return self.company_id.self_billed_journal_id
+        if (
             not partner
             or partner.id == self.env.ref("pms.various_pms_partner").id
             or (

--- a/pms/models/res_company.py
+++ b/pms/models/res_company.py
@@ -58,3 +58,20 @@ class ResCompany(models.Model):
         index=True,
         ondelete="restrict",
     )
+
+    self_billed_journal_id = fields.Many2one(
+        string="Self billed journal",
+        help="Journal used to create self billing",
+        comodel_name="account.journal",
+        index=True,
+        ondelete="restrict",
+    )
+    self_billed_tax_ids = fields.Many2many(
+        string="Self billed taxes",
+        help="Taxes used to create self billing",
+        comodel_name="account.tax",
+        relation="company_autoinvoicing_tax_rel",
+        column1="company_id",
+        column2="tax_id",
+        domain="[('company_id', '=', id)]",
+    )


### PR DESCRIPTION
Enhancements to the billing process by adding support for self-billed journals and taxes. The changes ensure that the system correctly applies self-billed journals and taxes when the partner is the same as the company partner.

Key changes include:

### Self-billing support:

* Added `self_billed_journal_id` and `self_billed_tax_ids` fields to the `ResCompany` model to store the self-billed journal and taxes information.

### Invoice and tax computation:

* Updated `_get_folio_default_journal` method in `pms_property.py` to return the self-billed journal if the partner is the company partner.
* Modified `_compute_tax_ids` method in `pms_reservation.py` to check for self-billed taxes when the partner is the company partner.
* Enhanced `_compute_tax_ids` method in `pms_service.py` to apply self-billed taxes when the service partner is the company partner.