### PR TITLE
14.0 apply board service by pricelist filter

### DIFF
--- a/pms/models/pms_board_service_room_type.py
+++ b/pms/models/pms_board_service_room_type.py
@@ -60,6 +60,11 @@ class PmsBoardServiceRoomType(models.Model):
         string="Apply by Default",
         help="Indicates if this board service is applied by default in the room type",
     )
+    pricelist_ids = fields.Many2many(
+        string="Pricelists",
+        help="Pricelists where this Board Service is available",
+        comodel_name="product.pricelist",
+    )
 
     @api.depends("board_service_line_ids.amount")
     def _compute_board_amount(self):
@@ -86,11 +91,11 @@ class PmsBoardServiceRoomType(models.Model):
                     "by_default"
                 )
             )
-            # TODO Check properties (with different propertys is allowed)
             if any(
                 default_boards.filtered(
-                    lambda l: l.id != record.id
-                    and l.pms_property_id == record.pms_property_id
+                    lambda board: board.id != record.id
+                    and board.pms_property_id == record.pms_property_id
+                    and board.pricelist_ids == record.pricelist_ids
                 )
             ):
                 raise UserError(_("""Only can set one default board service"""))

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -770,12 +770,24 @@ class PmsReservation(models.Model):
     def _compute_board_service_room_id(self):
         for reservation in self:
             if reservation.pricelist_id and reservation.room_type_id:
-                board_service_default = self.env["pms.board.service.room.type"].search(
+                board_services_candidates = self.env[
+                    "pms.board.service.room.type"
+                ].search(
                     [
                         ("pms_room_type_id", "=", reservation.room_type_id.id),
                         ("by_default", "=", True),
                         ("pms_property_id", "=", reservation.pms_property_id.id),
                     ]
+                )
+                board_service_default = (
+                    board_services_candidates.filtered(
+                        lambda service: reservation.pricelist_id
+                        in service.pricelist_ids
+                    )
+                    or board_services_candidates.filtered(
+                        lambda service: not service.pricelist_ids
+                    )
+                    or False
                 )
                 if (
                     not reservation.board_service_room_id

--- a/pms/views/pms_room_type_views.xml
+++ b/pms/views/pms_room_type_views.xml
@@ -75,6 +75,10 @@
                                         icon="fa-2x fa-bars"
                                         name="open_board_lines_form"
                                     />
+                                    <field
+                                        name="pricelist_ids"
+                                        widget="many2many_tags"
+                                    />
                                 </tree>
                             </field>
                         </page>

--- a/pms/wizards/wizard_folio_changes.py
+++ b/pms/wizards/wizard_folio_changes.py
@@ -390,6 +390,10 @@ class WizardFolioChanges(models.TransientModel):
                             reservation.folio_id.pms_property_id.id
                             == x.pms_property_id.ids
                         )
+                        and (
+                            not x.pricelist_ids
+                            or reservation.pricelist_id.id in x.pricelist_ids.ids
+                        )
                     )
                 )
 


### PR DESCRIPTION
This pull request includes several changes to the `pms` module, focusing on adding pricelist functionality to board services and improving the logic for handling default board services. The most important changes include adding a new field to the `PmsBoardServiceRoomType` model, updating constraints and computations involving board services, and modifying views to include the new field.

### Enhancements to Board Services:

* [`pms/models/pms_board_service_room_type.py`](diffhunk://#diff-44a2b2639d589a24dd8141949d2cae73e186056b5c435abc2dc0f51fe1f6a605R63-R67): Added a new `pricelist_ids` field to the `PmsBoardServiceRoomType` model to specify the pricelists where the board service is available.
* [`pms/models/pms_board_service_room_type.py`](diffhunk://#diff-44a2b2639d589a24dd8141949d2cae73e186056b5c435abc2dc0f51fe1f6a605L89-R98): Updated the `constrains_duplicated_board_default` method to include the new `pricelist_ids` field in the constraint check.

### Improvements to Reservation Logic:

* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L773-R791): Modified the `_compute_board_service_room_id` method to filter board services based on the `pricelist_ids` field, ensuring the correct board service is applied to reservations.
* [`pms/wizards/wizard_folio_changes.py`](diffhunk://#diff-ccdd732c3ac01cfa535cb14494fb914bcfdf6beb7b3c868b0b29e6eede38cd9fR393-R396): Updated the `_add_board_service` method to check the `pricelist_ids` field when adding board services to reservations.

### Updates to Views:

* [`pms/views/pms_room_type_views.xml`](diffhunk://#diff-d122ed0fe31835dd118af307cbcebbea4dcf75d6c79e006a7303c2efcb223c51R78-R81): Added the `pricelist_ids` field to the room type views, allowing users to manage pricelists for board services directly from the UI.