### PR TITLE
[IMP]pms: allowd journal filters by room

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -2082,7 +2082,10 @@ class PmsFolio(models.Model):
         (making sure to call super() to establish a clean extension chain).
         """
         self.ensure_one()
-        journal = self.pms_property_id._get_folio_default_journal(partner_invoice_id)
+        journal = self.pms_property_id._get_folio_default_journal(
+            partner_invoice_id=partner_invoice_id,
+            room_ids=self.reservation_ids.mapped("reservation_line_ids.room_id.id"),
+        )
         if not journal:
             journal = (
                 self.env["account.move"]

--- a/pms/views/account_journal_views.xml
+++ b/pms/views/account_journal_views.xml
@@ -6,6 +6,12 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="pms_property_ids" widget="many2many_tags" />
+                <field name="allowed_room_ids" invisible="1" />
+                <field
+                    name="room_filter_ids"
+                    string="Room Types"
+                    widget="many2many_tags"
+                />
                 <field
                     name="allowed_pms_payments"
                     attrs="{'invisible':[('type','not in',('bank', 'cash'))]}"

--- a/pms/wizards/folio_make_invoice_advance.py
+++ b/pms/wizards/folio_make_invoice_advance.py
@@ -160,7 +160,10 @@ class FolioAdvancePaymentInv(models.TransientModel):
             "ref": order.name,
             "move_type": "out_invoice",
             "journal_id": order.pms_property_id._get_folio_default_journal(
-                partner_id
+                partner_invoice_id=partner_id,
+                room_ids=order.mapped(
+                    "reservation_ids.reservation_line_ids.room_id.id"
+                ),
             ).id,
             "invoice_origin": order.name,
             "invoice_user_id": order.user_id.id,

--- a/pms/wizards/wizard_payment_folio.py
+++ b/pms/wizards/wizard_payment_folio.py
@@ -46,7 +46,11 @@ class WizardPaymentFolio(models.TransientModel):
         self.ensure_one()
         journal_ids = False
         if self.folio_id:
-            journal_ids = self.folio_id.pms_property_id._get_payment_methods().ids
+            journal_ids = self.folio_id.pms_property_id._get_payment_methods(
+                room_ids=self.folio_id.mapped(
+                    "reservation_ids.reservation_line_ids.room_id.id"
+                ),
+            ).ids
         self.allowed_method_ids = journal_ids
 
     def button_payment(self):


### PR DESCRIPTION
This pull request introduces several changes to the `pms` module, primarily focusing on enhancing the filtering and handling of rooms and payment methods associated with account journals and folios. The most important changes include adding new fields for room filtering, updating methods to accommodate these fields, and modifying related views and wizards.

Enhancements to room filtering:

* [`pms/models/account_journal.py`](diffhunk://#diff-5e2cf923d94c56c55d5f5d19f1447fbe45cf41b6ea75707afa917a06d4718e82R35-R52): Added `allowed_room_ids` and `room_filter_ids` fields to the `AccountJournal` model to filter rooms in reservations. Implemented `_compute_allowed_room_ids` method to compute the allowed rooms based on `pms_property_ids`. [[1]](diffhunk://#diff-5e2cf923d94c56c55d5f5d19f1447fbe45cf41b6ea75707afa917a06d4718e82R35-R52) [[2]](diffhunk://#diff-5e2cf923d94c56c55d5f5d19f1447fbe45cf41b6ea75707afa917a06d4718e82R63-R74)

Updates to folio and invoice preparation:

* [`pms/models/pms_folio.py`](diffhunk://#diff-fb770f511eb53a835c18fb8970e4be51ac0a7091ab13a6d086167fd6b9c079c7L2085-R2088): Modified `_prepare_invoice` method to pass `room_ids` when getting the default journal for folios.
* [`pms/wizards/folio_make_invoice_advance.py`](diffhunk://#diff-f608d28dee47391291befc00462ded3aab66f1717c35c4427607c5ddf15d58c4L163-R166): Updated `_prepare_invoice_values` method to include `room_ids` when determining the journal for the invoice.

Adjustments to payment methods:

* [`pms/models/pms_property.py`](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bL572-R578): Enhanced `_get_payment_methods` method to filter payment methods based on `room_ids`. [[1]](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bL572-R578) [[2]](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bR594-R598)
* [`pms/wizards/wizard_payment_folio.py`](diffhunk://#diff-1b85c22927d5b1adb80bb18e7760fe763b6dcc63edb49614251b3c8b3dc6e0c3L49-R53): Updated `_compute_allowed_method_ids` method to pass `room_ids` when fetching payment methods.

Modifications to default journal selection:

* [`pms/models/pms_property.py`](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bL894-R904): Updated `_get_folio_default_journal` method to filter journals by `room_ids` for both simplified and normal invoices. [[1]](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bL894-R904) [[2]](diffhunk://#diff-fc4b5d1cb09bd17edb21629cf8bcc3a52c68a57b31d48cfed051e2a331af850bR913-R962)

Changes to views:

* [`pms/views/account_journal_views.xml`](diffhunk://#diff-091ab5490d9becaacd948a891f3643053c3df750d4718558570ab308b2a44130R9-R14): Added fields `allowed_room_ids` and `room_filter_ids` to the account journal form view.