### PR TITLE
[IMP]pms: add tourist tax computation

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
       - name: Get python version
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/pms/models/pms_checkin_partner.py
+++ b/pms/models/pms_checkin_partner.py
@@ -796,8 +796,11 @@ class PmsCheckinPartner(models.Model):
 
     def write(self, vals):
         res = super().write(vals)
-        for record in self:
-            record.reservation_id._update_tourist_tax_service()
+        reservations = self.mapped("reservation_id")
+        for reservation in reservations:
+            tourist_tax_services_cmds = reservation._compute_tourist_tax_lines()
+            if tourist_tax_services_cmds:
+                reservation.write({"service_ids": tourist_tax_services_cmds})
         return res
 
     def unlink(self):

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -7,7 +7,6 @@ import time
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
 
@@ -2103,7 +2102,13 @@ class PmsReservation(models.Model):
             record.action_cancel()
 
         record._check_services(vals)
-        record._add_tourist_tax_service()
+        tourist_tax_services_cmds = record._compute_tourist_tax_lines()
+        if tourist_tax_services_cmds:
+            record.write(
+                {
+                    "service_ids": tourist_tax_services_cmds,
+                }
+            )
         return record
 
     def write(self, vals):
@@ -2168,13 +2173,20 @@ class PmsReservation(models.Model):
                 "sale_channel_origin_id"
             ]
 
-        self._check_services(vals)
-        # Only check if adult to avoid to check capacity in intermediate states (p.e. flush)
-        # that not take access to possible extra beds service in vals
-        if "adults" in vals:
-            self._check_capacity()
-        if "checkin" in vals or "checkout" in vals or "reservation_line_ids" in vals:
-            self._update_tourist_tax_service()
+        for record in self:
+            record._check_services(vals)
+            # Only check if adult to avoid to check capacity in intermediate states (p.e. flush)
+            # that not take access to possible extra beds service in vals
+            if "adults" in vals:
+                record._check_capacity()
+            if (
+                "checkin" in vals
+                or "checkout" in vals
+                or "reservation_line_ids" in vals
+            ):
+                tourist_tax_services_cmds = record._compute_tourist_tax_lines()
+                if tourist_tax_services_cmds:
+                    record.write({"service_ids": tourist_tax_services_cmds})
         return res
 
     def _get_folio_vals(self, reservation_vals):
@@ -2524,138 +2536,184 @@ class PmsReservation(models.Model):
             "url": self.get_portal_url(),
         }
 
-    def _add_tourist_tax_service(self):
-        for record in self:
-            tourist_tax_products = self.env["product.product"].search(
-                [("is_tourist_tax", "=", True)]
-            )
-            for product in tourist_tax_products:
-                if product.touristic_calculation == "occupancy":
-                    checkins = record.checkin_partner_ids.filtered_domain(
-                        safe_eval(product.occupancy_domain)
-                    )
-                    quantity = len(checkins)
-                elif product.touristic_calculation == "nights":
-                    if not record.filtered_domain(safe_eval(product.nights_domain)):
-                        continue
-                    quantity = (record.checkout - record.checkin).days
-                elif product.touristic_calculation == "occupancyandnights":
-                    checkins = record.checkin_partner_ids.filtered_domain(
-                        safe_eval(product.occupancy_domain)
-                    )
-                    if not record.filtered_domain(safe_eval(product.nights_domain)):
-                        continue
-                    quantity = len(checkins) * (record.checkout - record.checkin).days
-                else:
-                    quantity = 1
+    def _compute_tourist_tax_lines(self):
+        """Return ORM commands to sync tourist tax services on this reservation."""
+        self.ensure_one()
 
-                if quantity == 0:
+        tax_products = self._get_tourist_tax_products()
+        if not tax_products:
+            return []
+
+        nightly_dates = self._get_nightly_dates()
+        grouped_lines = self._build_grouped_tax_lines(tax_products, nightly_dates)
+        existing_services = self._get_existing_tourist_tax_services()
+        return self._build_service_commands(grouped_lines, existing_services)
+
+    def _get_tourist_tax_products(self):
+        return self.env["product.product"].search([("is_tourist_tax", "=", True)])
+
+    def _get_nightly_dates(self):
+        return [
+            self.checkin + datetime.timedelta(days=i)
+            for i in range((self.checkout - self.checkin).days)
+        ]
+
+    def _build_grouped_tax_lines(self, products, nightly_dates):
+        grouped = {}
+        for night_index, night_date in enumerate(nightly_dates):
+            night_number = night_index + 1
+            for product in products:
+                if not self._should_apply_product_for_night(
+                    product, night_date, night_number
+                ):
                     continue
 
-                product = product.with_context(
-                    lang=record.partner_id.lang,
-                    partner=record.partner_id.id,
-                    quantity=quantity,
-                    date=record.date_order,
-                    consumption_date=record.checkin,
-                    pricelist=record.pricelist_id.id,
-                    uom=product.uom_id.id,
-                    property=record.pms_property_id.id,
+                quantity = (
+                    self._get_applicable_guest_count(product)
+                    if product.per_person
+                    else 1
                 )
-                price = self.env["account.tax"]._fix_tax_included_price_company(
-                    product.price,
-                    product.taxes_id,
-                    record.tax_ids,
-                    record.pms_property_id.company_id,
-                )
+                price_unit = self._get_product_price(product, quantity, night_date)
+                key = (product.id, price_unit)
 
-                self.env["pms.service"].create(
-                    {
-                        "reservation_id": record.id,
-                        "folio_id": record.folio_id.id,
-                        "product_id": product.id,
-                        "name": product.name,
-                        "service_line_ids": [
+                line = {
+                    "product_id": product.id,
+                    "day_qty": quantity,
+                    "price_unit": price_unit,
+                    "date": night_date,
+                }
+                grouped.setdefault(key, []).append(line)
+        return grouped
+
+    def _should_apply_product_for_night(self, product, night_date, night_number):
+        return (
+            self._is_mmdd_in_range(
+                night_date, product.tourist_tax_date_start, product.tourist_tax_date_end
+            )
+            and night_number >= product.tourist_tax_apply_from_night
+            and (
+                not product.tourist_tax_apply_to_night
+                or night_number <= product.tourist_tax_apply_to_night
+            )
+        )
+
+    def _get_applicable_guest_count(self, product):
+        return len(
+            self._get_guests_by_age(
+                product.tourist_tax_min_age,
+                product.tourist_tax_max_age,
+            )
+        )
+
+    def _get_product_price(self, product, quantity, night_date):
+        priced = product.with_context(
+            lang=self.partner_id.lang,
+            partner=self.partner_id.id,
+            quantity=quantity,
+            date=fields.Date.today(),
+            consumption_date=night_date,
+            pricelist=self.pricelist_id.id,
+            uom=product.uom_id.id,
+            property=self.pms_property_id.id,
+        )
+        return self.env["account.tax"]._fix_tax_included_price_company(
+            priced.price,
+            priced.taxes_id,
+            self.tax_ids,
+            self.pms_property_id.company_id,
+        )
+
+    def _get_existing_tourist_tax_services(self):
+        return self.service_ids.filtered(
+            lambda s: s.product_id.product_tmpl_id.is_tourist_tax
+        )
+
+    def _build_service_commands(self, grouped_lines, existing_services):
+        cmds = []
+        existing_by_product = {s.product_id.id: s for s in existing_services}
+        new_product_ids = {product_id for product_id, _ in grouped_lines}
+
+        # Remove services no longer needed
+        for product_id in existing_by_product.keys() - new_product_ids:
+            cmds.append((2, existing_by_product[product_id].id))
+
+        for (product_id, _price_unit), new_lines in grouped_lines.items():
+            product = self.env["product.product"].browse(product_id)
+            service = existing_by_product.get(product_id)
+
+            if not service:
+                cmds.append(
+                    (
+                        0,
+                        0,
+                        {
+                            "reservation_id": self.id,
+                            "folio_id": self.folio_id.id,
+                            "product_id": product.id,
+                            "name": product.name,
+                            "per_day": True,
+                            "service_line_ids": [(0, 0, line) for line in new_lines],
+                        },
+                    )
+                )
+            else:
+                existing_lines = {line.date: line for line in service.service_line_ids}
+                new_lines_by_date = {line["date"]: line for line in new_lines}
+                line_cmds = []
+
+                for date in existing_lines.keys() & new_lines_by_date.keys():
+                    existing = existing_lines[date]
+                    new = new_lines_by_date[date]
+                    if (
+                        existing.day_qty != new["day_qty"]
+                        or existing.price_unit != new["price_unit"]
+                    ):
+                        line_cmds.append(
                             (
-                                0,
-                                0,
+                                1,
+                                existing.id,
                                 {
-                                    "product_id": product.id,
-                                    "day_qty": quantity,
-                                    "price_unit": price,
-                                    "date": record.checkin,
+                                    "day_qty": new["day_qty"],
+                                    "price_unit": new["price_unit"],
                                 },
                             )
-                        ],
-                    }
-                )
+                        )
+                for date in existing_lines.keys() - new_lines_by_date.keys():
+                    line_cmds.append((2, existing_lines[date].id))
+                for date in new_lines_by_date.keys() - existing_lines.keys():
+                    line_cmds.append((0, 0, new_lines_by_date[date]))
 
-    def _update_tourist_tax_service(self):
-        for record in self:
-            services = self.env["pms.service"].search(
-                [
-                    ("reservation_id", "=", record.id),
-                    ("product_id.is_tourist_tax", "=", True),
-                ]
+                if line_cmds:
+                    cmds.append((1, service.id, {"service_line_ids": line_cmds}))
+
+        return cmds
+
+    def _get_guests_by_age(self, min_age=None, max_age=None):
+        today = fields.Date.today()
+        guests = self.checkin_partner_ids
+
+        def age(birthdate):
+            return (today - birthdate).days // 365 if birthdate else 0
+
+        filtered = guests.filtered(
+            lambda g: (
+                (not min_age or age(g.birthdate_date) >= min_age)
+                and (not max_age or age(g.birthdate_date) <= max_age)
             )
-            for service in services:
-                product = service.product_id
-                if product.touristic_calculation == "occupancy":
-                    checkins = record.checkin_partner_ids.filtered_domain(
-                        safe_eval(product.occupancy_domain)
-                    )
-                    quantity = len(checkins)
-                elif product.touristic_calculation == "nights":
-                    if not record.filtered_domain(safe_eval(product.nights_domain)):
-                        service.unlink()
-                        continue
-                    quantity = (record.checkout - record.checkin).days
-                elif product.touristic_calculation == "occupancyandnights":
-                    checkins = record.checkin_partner_ids.filtered_domain(
-                        safe_eval(product.occupancy_domain)
-                    )
-                    if not record.filtered_domain(safe_eval(product.nights_domain)):
-                        service.unlink()
-                        continue
-                    quantity = len(checkins) * (record.checkout - record.checkin).days
-                else:
-                    quantity = 1
+        )
+        return filtered
 
-                if quantity == 0:
-                    service.unlink()
-                    continue
+    def _is_mmdd_in_range(self, check_date, start_mmdd, end_mmdd):
+        """Check if a date falls between two MM-DD values,
+        supporting wrap-around (e.g. Nov–Feb)."""
+        if not start_mmdd or not end_mmdd:
+            return True
 
-                product = product.with_context(
-                    lang=record.partner_id.lang,
-                    partner=record.partner_id.id,
-                    quantity=quantity,
-                    date=record.date_order,
-                    consumption_date=record.checkin,
-                    pricelist=record.pricelist_id.id,
-                    uom=product.uom_id.id,
-                    property=record.pms_property_id.id,
-                )
-                price = self.env["account.tax"]._fix_tax_included_price_company(
-                    product.price,
-                    product.taxes_id,
-                    record.tax_ids,
-                    record.pms_property_id.company_id,
-                )
+        check_md = (check_date.month, check_date.day)
+        start_md = tuple(map(int, start_mmdd.split("-")))
+        end_md = tuple(map(int, end_mmdd.split("-")))
 
-                service.write(
-                    {
-                        "service_line_ids": [
-                            (5, 0, 0),
-                            (
-                                0,
-                                0,
-                                {
-                                    "product_id": product.id,
-                                    "day_qty": quantity,
-                                    "price_unit": price,
-                                    "date": record.checkin,
-                                },
-                            ),
-                        ]
-                    }
-                )
+        if start_md <= end_md:
+            return start_md <= check_md <= end_md
+        else:
+            return check_md >= start_md or check_md <= end_md

--- a/pms/models/product_template.py
+++ b/pms/models/product_template.py
@@ -1,6 +1,10 @@
 # Copyright 2017  Alexandre Díaz
 # Copyright 2017  Dario Lodeiros
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from datetime import date
+
+import babel
+
 from odoo import api, fields, models
 
 
@@ -17,8 +21,8 @@ class ProductTemplate(models.Model):
         relation="product_template_pms_property_rel",
         column1="product_tmpl_id",
         column2="pms_property_id",
-        ondelete="restrict",
         check_pms_properties=True,
+        ondelete="restrict",
     )
     per_day = fields.Boolean(
         string="Unit increment per day",
@@ -65,25 +69,30 @@ class ProductTemplate(models.Model):
         help="Indicates if that product is a tourist tax",
         default=False,
     )
-    touristic_calculation = fields.Selection(
-        string="Touristic calculation",
-        help="Indicates how the tourist tax is calculated",
-        selection=[
-            ("occupany", "Occupancy"),
-            ("nights", "Nights"),
-            ("occupancyandnights", "Occupancy and Nights"),
-        ],
-        default="occupancyandnights",
+    tourist_tax_date_start = fields.Selection(
+        selection=lambda self: self._get_mmdd_selection(),
+        string="Start Date (Annual)",
+        required=False,
     )
-    occupancy_domain = fields.Char(
-        string="Occupancy domain",
-        help="Domain to filter checkins",
-        default="",
+    tourist_tax_date_end = fields.Selection(
+        selection=lambda self: self._get_mmdd_selection(),
+        string="End Date (Annual)",
+        required=False,
     )
-    nights_domain = fields.Char(
-        string="Nights domain",
-        help="Domain to filter reservations",
-        default="[('state', '!=', 'cancel')]",
+    tourist_tax_apply_from_night = fields.Integer(
+        string="Apply From Night",
+        default=1,
+        help="Night number the rule starts applying (e.g., 1 = first night)",
+    )
+    tourist_tax_apply_to_night = fields.Integer(
+        string="Apply Until Night",
+        help="Night number the rule stops applying (optional)",
+    )
+    tourist_tax_min_age = fields.Integer(
+        string="Minimum Age", help="Applies only to guests with this age or older"
+    )
+    tourist_tax_max_age = fields.Integer(
+        string="Maximum Age", help="Applies only to guests up to this age"
     )
     property_daily_limits = fields.One2many(
         string="Daily Limits per Property",
@@ -117,3 +126,37 @@ class ProductTemplate(models.Model):
                 record.id,
                 record.daily_limit,
             )
+
+    def write(self, vals):
+        if vals.get("is_tourist_tax") is True:
+            vals["is_pms_available"] = True
+            vals["per_day"] = True
+            vals["consumed_on"] = "before"
+        return super(ProductTemplate, self).write(vals)
+
+    def _get_mmdd_selection(self):
+        lang = self.env.lang or "en_US"
+        days_by_month = {
+            1: 31,
+            2: 29,
+            3: 31,
+            4: 30,
+            5: 31,
+            6: 30,
+            7: 31,
+            8: 31,
+            9: 30,
+            10: 31,
+            11: 30,
+            12: 31,
+        }
+
+        options = []
+        for month in range(1, 13):
+            for day in range(1, days_by_month[month] + 1):
+                mmdd = f"{month:02d}-{day:02d}"
+                dt = date(2024, month, day)  # Dummy year
+                label = babel.dates.format_date(dt, format="d MMMM", locale=lang)
+                options.append((mmdd, label.capitalize()))
+                # Capitalize first letter for consistency
+        return options

--- a/pms/tests/__init__.py
+++ b/pms/tests/__init__.py
@@ -41,3 +41,4 @@ from . import test_shared_room
 
 # from . import test_automated_mails
 from . import test_pms_service
+from . import test_pms_tourist_tax

--- a/pms/tests/test_pms_tourist_tax.py
+++ b/pms/tests/test_pms_tourist_tax.py
@@ -1,0 +1,299 @@
+import datetime
+import logging
+
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.tests.common import tagged
+
+from .common import TestPms
+
+_logger = logging.getLogger(__name__)
+
+
+@tagged("tourist_tax")
+class TestTouristTaxComputation(TestPms):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.room_type_double = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Double Test",
+                "default_code": "DBL_Test",
+                "class_id": cls.room_type_class1.id,
+            }
+        )
+
+        cls.room1 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Double 101",
+                "room_type_id": cls.room_type_double.id,
+                "capacity": 2,
+                "extra_beds_allowed": 1,
+            }
+        )
+
+        cls.partner_adult = cls.env["res.partner"].create(
+            {
+                "firstname": "Adult",
+                "birthdate_date": "1990-01-01",
+            }
+        )
+
+        cls.partner_child = cls.env["res.partner"].create(
+            {
+                "firstname": "Child",
+                "birthdate_date": "2015-01-01",
+            }
+        )
+
+        cls.sale_channel_direct = cls.env["pms.sale.channel"].create(
+            {"name": "sale channel direct", "channel_type": "direct"}
+        )
+
+    @freeze_time("2025-07-01")
+    def test_tourist_tax_lines_correctly_generated(self):
+        """
+        Test that the tourist tax service lines are correctly computed for 3 nights
+        with one adult and one child (child is under age and excluded).
+        """
+        self.env["product.product"].create(
+            {
+                "name": "Tourist Tax",
+                "list_price": 2.0,
+                "is_tourist_tax": True,
+                "per_person": True,
+                "tourist_tax_date_start": "06-01",
+                "tourist_tax_date_end": "09-30",
+                "tourist_tax_apply_from_night": 1,
+                "tourist_tax_apply_to_night": 3,
+                "tourist_tax_min_age": 14,
+            }
+        )
+
+        checkin = fields.Date.today()
+        checkout = checkin + datetime.timedelta(days=3)
+
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_adult.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "adults": 2,
+                "checkin_partner_ids": [
+                    (0, 0, {"partner_id": self.partner_adult.id}),
+                    (0, 0, {"partner_id": self.partner_child.id}),
+                ],
+                "pms_property_id": self.pms_property1.id,
+                "pricelist_id": self.pricelist1.id,
+            }
+        )
+
+        tax_services = reservation.service_ids.filtered(
+            lambda s: s.product_id.product_tmpl_id.is_tourist_tax
+        )
+        self.assertEqual(
+            len(tax_services), 1, "Should generate one tourist tax service"
+        )
+
+        service = tax_services[0]
+        self.assertEqual(
+            len(service.service_line_ids), 3, "Should have 3 nights of tax"
+        )
+
+        for line in service.service_line_ids:
+            self.assertEqual(line.day_qty, 1, "Only adult should be taxed")
+            self.assertEqual(
+                line.price_unit, 2.0, "Price should match product list_price"
+            )
+
+    @freeze_time("2025-12-15")
+    def test_tourist_tax_not_applied_outside_period(self):
+        """
+        Test that tourist tax is not applied outside the configured date range.
+        """
+        self.env["product.product"].create(
+            {
+                "name": "Tourist Tax",
+                "list_price": 2.0,
+                "is_tourist_tax": True,
+                "per_person": True,
+                "tourist_tax_date_start": "06-01",
+                "tourist_tax_date_end": "09-30",
+                "tourist_tax_apply_from_night": 1,
+                "tourist_tax_apply_to_night": 3,
+                "tourist_tax_min_age": 14,
+            }
+        )
+
+        checkin = fields.Date.today()
+        checkout = checkin + datetime.timedelta(days=2)
+
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_adult.id,
+                "adults": 2,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "checkin_partner_ids": [
+                    (0, 0, {"partner_id": self.partner_adult.id}),
+                ],
+                "pms_property_id": self.pms_property1.id,
+                "pricelist_id": self.pricelist1.id,
+            }
+        )
+
+        tax_services = reservation.service_ids.filtered(
+            lambda s: s.product_id.product_tmpl_id.is_tourist_tax
+        )
+
+        self.assertEqual(
+            len(tax_services),
+            0,
+            "No tax should be applied outside the defined MM-DD range",
+        )
+
+    @freeze_time("2025-07-01")
+    def test_tourist_tax_stops_after_max_night(self):
+        """
+        Test that tax is not applied beyond the configured max night (apply_to_night = 3).
+        """
+        self.env["product.product"].create(
+            {
+                "name": "Tourist Tax",
+                "list_price": 2.0,
+                "is_tourist_tax": True,
+                "per_person": True,
+                "tourist_tax_date_start": "06-01",
+                "tourist_tax_date_end": "09-30",
+                "tourist_tax_apply_from_night": 1,
+                "tourist_tax_apply_to_night": 3,
+                "tourist_tax_min_age": 14,
+            }
+        )
+
+        checkin = fields.Date.today()
+        checkout = checkin + datetime.timedelta(days=5)
+
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_adult.id,
+                "adults": 2,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "checkin_partner_ids": [
+                    (0, 0, {"partner_id": self.partner_adult.id}),
+                ],
+                "pms_property_id": self.pms_property1.id,
+                "pricelist_id": self.pricelist1.id,
+            }
+        )
+
+        tax_services = reservation.service_ids.filtered(
+            lambda s: s.product_id.product_tmpl_id.is_tourist_tax
+        )
+
+        self.assertEqual(
+            len(tax_services), 1, "Should generate one tourist tax service"
+        )
+        service = tax_services[0]
+
+        self.assertEqual(
+            len(service.service_line_ids), 3, "Tax should only apply to first 3 nights"
+        )
+
+    @freeze_time("2025-06-28")
+    def test_multiple_tourist_taxes_applied_by_season(self):
+        """
+        Test that two different tourist taxes
+        (low and high season) apply correctly over 8 nights.
+        """
+        # Arrange
+        low_season_tax = self.env["product.product"].create(
+            {
+                "name": "Tourist Tax Low Season",
+                "list_price": 1.5,
+                "is_tourist_tax": True,
+                "per_person": True,
+                "tourist_tax_date_start": "01-01",
+                "tourist_tax_date_end": "06-30",
+                "tourist_tax_apply_from_night": 1,
+                "tourist_tax_apply_to_night": 3,
+                "tourist_tax_min_age": 14,
+            }
+        )
+
+        high_season_tax = self.env["product.product"].create(
+            {
+                "name": "Tourist Tax High Season",
+                "list_price": 2.0,
+                "is_tourist_tax": True,
+                "per_person": True,
+                "tourist_tax_date_start": "07-01",
+                "tourist_tax_date_end": "09-30",
+                "tourist_tax_apply_from_night": 1,
+                "tourist_tax_apply_to_night": 99,
+                "tourist_tax_min_age": 14,
+            }
+        )
+
+        checkin = fields.Date.today()  # 2025-06-28
+        checkout = checkin + datetime.timedelta(days=8)  # until 2025-07-06
+
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_adult.id,
+                "adults": 1,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "checkin_partner_ids": [
+                    (0, 0, {"partner_id": self.partner_adult.id}),
+                ],
+                "pms_property_id": self.pms_property1.id,
+                "pricelist_id": self.pricelist1.id,
+            }
+        )
+
+        # Act
+        tax_services = reservation.service_ids.filtered(
+            lambda s: s.product_id.product_tmpl_id.is_tourist_tax
+        )
+        # Assert
+        self.assertEqual(
+            len(tax_services),
+            2,
+            "Should generate two tourist tax services (low and high season)",
+        )
+
+        low = tax_services.filtered(lambda s: s.product_id == low_season_tax)
+        high = tax_services.filtered(lambda s: s.product_id == high_season_tax)
+
+        self.assertEqual(
+            len(low.service_line_ids),
+            3,
+            "Low season should apply to first 3 nights (06/28–06/30)",
+        )
+        self.assertEqual(
+            len(high.service_line_ids),
+            5,
+            "High season should apply to last 5 nights (07/01–07/05)",
+        )
+
+        for line in low.service_line_ids:
+            self.assertEqual(line.day_qty, 1)
+            self.assertEqual(line.price_unit, 1.5)
+
+        for line in high.service_line_ids:
+            self.assertEqual(line.day_qty, 1)
+            self.assertEqual(line.price_unit, 2.0)

--- a/pms/views/product_template_views.xml
+++ b/pms/views/product_template_views.xml
@@ -35,6 +35,30 @@
                             />
                         </group>
                     </group>
+                    <group
+                        string="Tourist Tax"
+                        colspan="4"
+                        attrs="{'invisible': [('is_tourist_tax', '=', False)]}"
+                    >
+                        <group>
+                            <field name="tourist_tax_date_start" />
+                            <field name="tourist_tax_date_end" />
+                        </group>
+                        <group>
+                            <field name="tourist_tax_apply_from_night" />
+                            <field name="tourist_tax_apply_to_night" />
+                        </group>
+                        <group>
+                            <field
+                                name="tourist_tax_min_age"
+                                attrs="{'invisible': [('per_person', '=', False)]}"
+                            />
+                            <field
+                                name="tourist_tax_max_age"
+                                attrs="{'invisible': [('per_person', '=', False)]}"
+                            />
+                        </group>
+                    </group>
                     <group>
                         <field
                             name="property_daily_limits"
@@ -51,24 +75,6 @@
                                 <field name="field_name" invisible="1" />
                             </tree>
                         </field>
-                    </group>
-                </page>
-                <page
-                    string="Tourist tax configuration"
-                    attrs="{'invisible': [('is_tourist_tax', '=', False)]}"
-                >
-                    <group>
-                        <field name="touristic_calculation" />
-                        <field
-                            name="occupancy_domain"
-                            widget="domain"
-                            options="{'model': 'pms.checkin.partner'}"
-                        />
-                        <field
-                            name="nights_domain"
-                            widget="domain"
-                            options="{'model': 'pms.reservation'}"
-                        />
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
This pull request includes significant changes to the handling of tourist tax services in the PMS module, specifically in the `pms_reservation` and `pms_checkin_partner` models. The changes focus on refactoring the computation and application of tourist tax lines, as well as updating the related product template fields.

Refactoring of tourist tax services:

* [`pms/models/pms_checkin_partner.py`](diffhunk://#diff-00f4785f1a443f9b632f2a7b76477f6470f763ce82127c6bb850a7dce7a6935cL799-R803): Modified the `write` method to compute and write tourist tax service commands for reservations.
* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L2106-R2112): Replaced the `_add_tourist_tax_service` method with `_compute_tourist_tax_lines` to generate ORM commands for syncing tourist tax services. Updated the `create` and `write` methods to use the new computation method. [[1]](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L2106-R2112) [[2]](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L2171-R2190) [[3]](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L2527-R2720)

Updates to product template fields:

* [`pms/models/product_template.py`](diffhunk://#diff-22d57b75ea469d854da97acd39a87e19aa6c167293aa9b601e6dd789744cf20cL68-R95): Added new fields for tourist tax rules, including start and end dates, applicable nights, and guest age limits. Removed the old `touristic_calculation`, `occupancy_domain`, and `nights_domain` fields. [[1]](diffhunk://#diff-22d57b75ea469d854da97acd39a87e19aa6c167293aa9b601e6dd789744cf20cL68-R95) [[2]](diffhunk://#diff-22d57b75ea469d854da97acd39a87e19aa6c167293aa9b601e6dd789744cf20cR129-R162)

Test additions:

* [`pms/tests/__init__.py`](diffhunk://#diff-6f43fb1ab642398ab156848eceebba3555119749f34f215846747b0f2e142b9fR44): Included a new test module for tourist tax services.