### PR TITLE
[REF] pms: update avail rule checks to exclude checkout date from most of them

### DIFF
--- a/pms/models/pms_availability_plan.py
+++ b/pms/models/pms_availability_plan.py
@@ -66,14 +66,14 @@ class PmsAvailabilityPlan(models.Model):
         reservation_len = (checkout - checkin).days
         return any(
             [
-                (0 < item.max_stay < reservation_len),
-                (0 < item.min_stay > reservation_len),
+                (0 < item.max_stay < reservation_len and item.date != checkout),
+                (0 < item.min_stay > reservation_len and item.date != checkout),
                 (0 < item.max_stay_arrival < reservation_len and checkin == item.date),
                 (0 < item.min_stay_arrival > reservation_len and checkin == item.date),
-                item.closed,
+                (item.closed and item.date != checkout),
                 (item.closed_arrival and checkin == item.date),
                 (item.closed_departure and checkout == item.date),
-                (item.quota == 0 or item.max_avail == 0),
+                ((item.quota == 0 or item.max_avail == 0) and item.date != checkout),
             ]
         )
 

--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -434,6 +434,14 @@ class PmsProperty(models.Model):
             if pricelist_id:
                 pricelist = self.env["product.pricelist"].browse(pricelist_id)
             if pricelist and pricelist.availability_plan_id and not real_avail:
+                # The availability between two dates is given in two steps:
+                # 1- the date with minimum availability is obtained for each room_type
+                # 2- the availabilities of the room_type with dispo > 0 are added
+                days = [
+                    checkin + datetime.timedelta(days=i)
+                    for i in range((checkout - checkin).days + 1)
+                ]
+                day_avail = {}
                 domain_rules.append(
                     ("availability_plan_id", "=", pricelist.availability_plan_id.id)
                 )
@@ -443,19 +451,55 @@ class PmsProperty(models.Model):
                     ["date:day"],
                     lazy=False,
                 )
-                if len(rule_groups) > 0:
-                    # If in the group per day, some room type has the sale blocked,
-                    # we must subtract from that day the availability of that room type
-                    for group in rule_groups:
-                        items = self.env["pms.availability.plan.rule"].search(
-                            group["__domain"]
-                        )
-                        for item in items:
-                            if pricelist.availability_plan_id.any_rule_applies(
-                                checkin, checkout, item
-                            ):
-                                group["plan_avail"] -= item.plan_avail
-                    count_free_rooms = min(i["plan_avail"] for i in rule_groups)
+                grouped_rules = {}
+                for group in rule_groups:
+                    date = group["date"]
+                    rt_id = (
+                        group["room_type_id"][0] if group.get("room_type_id") else None
+                    )
+                    group_avail = group["plan_avail"]
+                    items = self.env["pms.availability.plan.rule"].search(
+                        group["__domain"]
+                    )
+                    for item in items:
+                        if pricelist.availability_plan_id.any_rule_applies(
+                            checkin, checkout, item
+                        ):
+                            group_avail -= item.plan_avail
+                    grouped_rules[(date, rt_id)] = (
+                        grouped_rules.get((date, rt_id), 0) + group_avail
+                    )
+                room_types = (
+                    [self.env["pms.room.type"].browse(room_type_id)]
+                    if room_type_id
+                    else record.room_ids.mapped("room_type_id")
+                )
+                for day in days:
+                    total_avail_day = 0
+                    for rt in room_types:
+                        key = (day, rt.id)
+                        if key in grouped_rules:
+                            total_avail_day += grouped_rules[key]
+                        else:
+                            # If not rule found for the any date/room_type
+                            # we need take account the default availability
+                            # of the room type
+                            default_avail = min(
+                                filter(
+                                    lambda x: x != -1,
+                                    [
+                                        rt.default_quota,
+                                        rt.default_max_avail,
+                                        rt.total_rooms_count.filtered(
+                                            lambda r: r.pms_property_id.id == record.id
+                                        ),
+                                    ],
+                                )
+                            )
+                            total_avail_day += default_avail
+                    day_avail[day] = total_avail_day
+                if day_avail:
+                    count_free_rooms = min(day_avail.values())
             record.availability = count_free_rooms
 
     @api.model

--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -430,6 +430,12 @@ class PmsProperty(models.Model):
             if room_type_id:
                 domain_rules.append(("room_type_id", "=", room_type_id))
 
+            room_types = (
+                [self.env["pms.room.type"].browse(room_type_id)]
+                if room_type_id
+                else record.room_ids.mapped("room_type_id")
+            )
+
             pricelist = False
             if pricelist_id:
                 pricelist = self.env["product.pricelist"].browse(pricelist_id)
@@ -453,27 +459,22 @@ class PmsProperty(models.Model):
                 )
                 grouped_rules = {}
                 for group in rule_groups:
-                    date = group["date"]
-                    rt_id = (
-                        group["room_type_id"][0] if group.get("room_type_id") else None
-                    )
-                    group_avail = group["plan_avail"]
-                    items = self.env["pms.availability.plan.rule"].search(
-                        group["__domain"]
-                    )
-                    for item in items:
-                        if pricelist.availability_plan_id.any_rule_applies(
-                            checkin, checkout, item
-                        ):
-                            group_avail -= item.plan_avail
-                    grouped_rules[(date, rt_id)] = (
-                        grouped_rules.get((date, rt_id), 0) + group_avail
-                    )
-                room_types = (
-                    [self.env["pms.room.type"].browse(room_type_id)]
-                    if room_type_id
-                    else record.room_ids.mapped("room_type_id")
-                )
+                    date = datetime.datetime.strptime(
+                        group["date:day"], "%d %b %Y"
+                    ).date()
+                    for rt in room_types:
+                        group_avail = group["plan_avail"]
+                        items = self.env["pms.availability.plan.rule"].search(
+                            group["__domain"]
+                        )
+                        for item in items:
+                            if pricelist.availability_plan_id.any_rule_applies(
+                                checkin, checkout, item
+                            ):
+                                group_avail -= item.plan_avail
+                        grouped_rules[(date, rt.id)] = (
+                            grouped_rules.get((date, rt.id), 0) + group_avail
+                        )
                 for day in days:
                     total_avail_day = 0
                     for rt in room_types:
@@ -490,8 +491,15 @@ class PmsProperty(models.Model):
                                     [
                                         rt.default_quota,
                                         rt.default_max_avail,
-                                        rt.total_rooms_count.filtered(
-                                            lambda r: r.pms_property_id.id == record.id
+                                        len(
+                                            record.with_context(
+                                                checkin=day,
+                                                checkout=day + datetime.timedelta(1),
+                                                room_type_id=rt.id,
+                                                current_lines=current_lines,
+                                                pricelist_id=pricelist.id,
+                                                real_avail=True,
+                                            ).free_room_ids
                                         ),
                                     ],
                                 )


### PR DESCRIPTION
This pull request includes updates to the `any_rule_applies` method in the `pms_availability_plan.py` file to improve the accuracy of reservation rule checks. The changes ensure that certain rules are only applied when the item's date does not match the checkout date.

Key changes:

* [`pms/models/pms_availability_plan.py`](diffhunk://#diff-c5e6a0e6984cd3c843f0ada6a671a88fa302d568cc81aadbe7c529e492fb0f32L69-R76): Updated conditions for `max_stay`, `min_stay`, `closed`, and availability checks to exclude cases where the item's date matches the checkout date