### PR TITLE
[FIX]pms: check checkout in compute_last_checkout

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -1369,12 +1369,14 @@ class PmsFolio(models.Model):
     @api.depends("reservation_ids", "reservation_ids.checkin")
     def _compute_first_checkin(self):
         for record in self:
-            if record.reservation_ids:
-                checkins = record.reservation_ids.mapped("checkin")
+            checkins = record.reservation_ids.filtered(lambda r: r.checkin).mapped(
+                "checkin"
+            )
+            if checkins:
                 record.first_checkin = min(checkins)
 
     def _compute_days_to_checkin(self):
-        for record in self:
+        for record in self.filtered("first_checkin"):
             record.days_to_checkin = (record.first_checkin - fields.Date.today()).days
 
     def _search_days_to_checkin(self, operator, value):
@@ -1394,14 +1396,13 @@ class PmsFolio(models.Model):
                     for reservation in record.reservation_ids
                     if reservation.checkout
                 ]
-                record.last_checkout = max(checkouts) if checkouts else None
+                record.last_checkout = max(checkouts) if checkouts else False
 
     def _compute_days_to_checkout(self):
         for record in self:
             if not record.last_checkout:
                 record.days_to_checkout = 0
             else:
-                # Calculate the number of days until the last checkout date
                 record.days_to_checkout = (
                     record.last_checkout - fields.Date.today()
                 ).days


### PR DESCRIPTION
This pull request refines the computation logic for check-in and check-out dates in the `pms/models/pms_folio.py` file. The changes improve accuracy and ensure consistent data handling by introducing filters and standardizing return values.

### Improvements to check-in and check-out computations:

* **Check-in computation refinement**:
  - Updated `_compute_first_checkin` to filter reservations with valid `checkin` dates before mapping them, ensuring that only relevant dates are considered.
  - Optimized `_compute_days_to_checkin` to skip records without a valid `first_checkin`, improving performance for irrelevant records.

* **Check-out computation refinement**:
  - Modified `_compute_last_checkout` to return `False` instead of `None` when no valid `checkout` dates exist, standardizing the return value for consistency.