### PR TITLE
[IMP]pms: includes board services in cancelation penalty

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2311,6 +2311,26 @@ class PmsReservation(models.Model):
         for record in self:
             record.to_assign = False
 
+    def _get_board_services_penalty_amount(self, record, dates, penalty_percent):
+        # Check if there are board services to add to the penalty
+        # Only services with 'consumed_on' set to 'before' or
+        # 'after' are considered.
+        # Services consumed only on the first or last day are excluded.
+        amount_board_service = 0
+        board_services = record.service_ids.filtered("is_board_service")
+        for board_service in board_services:
+            consumed_on = board_service.product_id.consumed_on
+            for service_line in board_service.service_line_ids:
+                service_date = fields.Date.from_string(service_line.date)
+                if (consumed_on == "before" and service_date in dates) or (
+                    consumed_on == "after"
+                    and service_date in [d + datetime.timedelta(days=1) for d in dates]
+                ):
+                    amount_board_service += (
+                        service_line.price_unit * service_line.day_qty
+                    )
+        return amount_board_service * penalty_percent / 100
+
     def _check_cancel_penalty(self):
         for record in self:
             # self.ensure_one()
@@ -2368,6 +2388,10 @@ class PmsReservation(models.Model):
                             * penalty_percent
                             / 100
                         )
+                        if record.service_ids:
+                            amount_penalty += self._get_board_services_penalty_amount(
+                                record, dates, penalty_percent
+                            )
                         if not amount_penalty:
                             return
                         if not record.company_id.cancel_penalty_product_id:


### PR DESCRIPTION
This pull request introduces enhancements to the penalty calculation logic in the `pms_reservation` model, specifically targeting board services. The changes ensure penalties account for board services consumed before or after the reservation dates, improving accuracy in penalty computations.

Enhancements to penalty calculation:

* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102R2314-R2333): Added a new helper method `_get_board_services_penalty_amount` to calculate the penalty amount for board services based on their consumption dates relative to the reservation dates. Only services consumed "before" or "after" the reservation dates are considered, excluding those consumed on the first or last day.
* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102R2391-R2394): Updated the `_check_cancel_penalty` method to include the penalty amount from board services by invoking the `_get_board_services_penalty_amount` method when `service_ids` are present.