### PR TITLE
[FIX]pms_l10n_es: NIE validation code

### DIFF
--- a/pms_l10n_es/data/pms_data.xml
+++ b/pms_l10n_es/data/pms_data.xml
@@ -53,7 +53,7 @@ permit_first_letter=id_number.name[0:1]
 permit_last_letter = id_number.name[
     len(id_number.name) - 1 : len(id_number.name)
 ]
-if (permit_first_letter.upper() in ['X','Y' 'Z']) and id_number.name[1:8].isdigit() and not permit_last_letter.isdigit():
+if (permit_first_letter.upper() in ['X','Y', 'Z']) and id_number.name[1:8].isdigit() and not permit_last_letter.isdigit():
     failed = False
 else:
     failed = True


### PR DESCRIPTION
This pull request fixes a minor typo in the conditional statement within the `pms_data.xml` file. Specifically, it adds a missing comma between `'Y'` and `'Z'` in the list of valid characters for `permit_first_letter`.

Change details:

* [`pms_l10n_es/data/pms_data.xml`](diffhunk://#diff-7af6a721f265f14ac5dec23c8274ef5b7fd10f633c528fec3efd29277d79143eL56-R56): Corrected the conditional logic by adding a comma between `'Y'` and `'Z'` in the `permit_first_letter.upper()` validation.