### PR TITLE
[IMP]pms: allow cancel no show reservations

### DIFF
--- a/pms/i18n/es.po
+++ b/pms/i18n/es.po
@@ -11998,7 +11998,7 @@ msgstr "Este registro se tiene en cuenta para calcular la disponibilidad"
 #: code:addons/pms/models/pms_reservation.py:0
 #, python-format
 msgid "This reservation cannot be cancelled"
-msgstr "No se puede hacer el checkout de la reserva"
+msgstr "No se puede cancelar esta reserva"
 
 #. module: pms
 #. odoo-python

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -1088,12 +1088,7 @@ class PmsReservation(models.Model):
         # Reservations can be cancelled
         for record in self:
             record.allowed_cancel = (
-                True
-                if (
-                    record.state not in ["done"]
-                    and fields.Date.today() <= record.checkout
-                )
-                else False
+                True if (record.state not in ["done", "onboard"]) else False
             )
 
     def _compute_ready_for_checkin(self):


### PR DESCRIPTION
This pull request includes updates to reservation management logic and translations in the PMS module. The changes ensure accurate handling of cancellation conditions and improve the clarity of Spanish translations.

### Reservation management logic updates:
* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L1091-R1091): Modified the `_compute_allowed_cancel` method to prevent cancellations for reservations in the "onboard" state, in addition to the "done" state. This change refines the conditions under which reservations can be canceled.

### Translation improvements:
* [`pms/i18n/es.po`](diffhunk://#diff-2007d76fb56ca2ccaa5d8f03eef79e48c57bce916feab0d2ba015f26a4adc93fL12001-R12001): Updated the Spanish translation for the message "This reservation cannot be cancelled" to "No se puede cancelar esta reserva," ensuring it accurately reflects the intended meaning.