### PR TITLE
[IMP]pms: add depends fields to compute_real_avail

### DIFF
--- a/pms/models/pms_availability.py
+++ b/pms/models/pms_availability.py
@@ -89,23 +89,21 @@ class PmsAvailability(models.Model):
         "reservation_line_ids",
         "reservation_line_ids.occupies_availability",
         "room_type_id.total_rooms_count",
+        "reservation_line_ids.room_id",
+        "reservation_line_ids.date",
         "parent_avail_id",
         "parent_avail_id.reservation_line_ids",
         "parent_avail_id.reservation_line_ids.occupies_availability",
+        "parent_avail_id.reservation_line_ids.room_id",
+        "parent_avail_id.reservation_line_ids.date",
         "child_avail_ids",
         "child_avail_ids.reservation_line_ids",
         "child_avail_ids.reservation_line_ids.occupies_availability",
+        "child_avail_ids.reservation_line_ids.room_id",
+        "child_avail_ids.reservation_line_ids.date",
     )
     def _compute_real_avail(self):
         for record in self:
-            Rooms = self.env["pms.room"]
-            total_rooms = Rooms.search_count(
-                [
-                    ("active", "=", True),
-                    ("room_type_id", "=", record.room_type_id.id),
-                    ("pms_property_id", "=", record.pms_property_id.id),
-                ]
-            )
             room_ids = record.room_type_id.room_ids.filtered(
                 lambda r, record=record: r.pms_property_id == record.pms_property_id
                 and r.active
@@ -118,7 +116,7 @@ class PmsAvailability(models.Model):
                     pms_property_id=record.pms_property_id.id,
                 )
             )
-            record.real_avail = total_rooms - count_rooms_not_avail
+            record.real_avail = len(room_ids) - count_rooms_not_avail
 
     @api.depends("reservation_line_ids", "reservation_line_ids.room_id")
     def _compute_parent_avail_id(self):


### PR DESCRIPTION
This pull request includes updates to the `pms/models/pms_availability.py` file, focusing on improving the computation of room availability by refining dependencies and simplifying logic. The most significant changes include adding new dependencies for room availability calculations and replacing the `search_count` logic with a more direct approach using filtered room IDs.

### Refinements to availability dependencies:

* Added `reservation_line_ids.room_id` and `reservation_line_ids.date` as dependencies for computing room availability, along with similar additions for `parent_avail_id` and `child_avail_ids`.

### Simplification of availability computation logic:

* Replaced duplicated logic in the `search_count` for already used total rooms with the use of filtered `room_ids` directly in `_compute_real_avail`. This simplifies the code and improves readability by avoiding an explicit search query.