### PR TITLE
[IMP][16.0] pms: add smart buttons container in property form view

### DIFF
--- a/pms/views/pms_property_views.xml
+++ b/pms/views/pms_property_views.xml
@@ -6,6 +6,7 @@
         <field name="arch" type="xml">
             <form string="Property Configuration">
                 <sheet>
+                    <div class="o_button_box" name="button_box" />
                     <label for="name" class="oe_edit_only" />
                     <h1>
                         <field name="name" class="oe_inline" />


### PR DESCRIPTION
### Description of the issue/feature this PR addresses

Modules extending `pms.property` need a common area in the form view to place smart buttons (stat buttons) without duplicating markup.

---

### Current behavior before PR

Modules injecting stat buttons into `pms.property` require custom XPath logic and may conflict when the button container (`div[name="button_box"]`) is not defined.

---

### Desired behavior after PR is merged

The `pms.property` form view includes a `<div name="button_box" class="o_button_box" />` before the `name` field, making it easier and safer for other modules to inject stat buttons in a consistent area.

---

### Related PRs, Related Issues

N/A

---

### Usage Example

External modules can now inject buttons using:

```xml
        <field name="inherit_id" ref="pms.pms_property_views_form" />
        <field name="arch" type="xml">
            <xpath expr="//div[@name='button_box']" position="inside">
            <button class="oe_stat_button" type="object" name="action_view_tickets" icon="fa-ticket">
                <div class="o_field_widget o_stat_info">
                    <span class="o_stat_value">
                        <field name="ticket_count" nolabel="1"/>
                        <span class="text-secondary fw-normal"> Tickets</span>
                    </span>
                </div>
            </button>
            </xpath>
        </field>
