### PR TITLE
[IMP]pms_l10n_es: delete expedition date like required checkin field …

### DIFF
--- a/pms_l10n_es/models/pms_checkin_partner.py
+++ b/pms_l10n_es/models/pms_checkin_partner.py
@@ -92,7 +92,6 @@ class PmsCheckinPartner(models.Model):
                     [
                         "document_number",
                         "document_type",
-                        "document_expedition_date",
                         "document_country_id",
                     ]
                 )

--- a/pms_l10n_es/wizards/traveller_report.py
+++ b/pms_l10n_es/wizards/traveller_report.py
@@ -79,7 +79,7 @@ def _ses_xml_contract_elements(comunicacion, reservation, people=False):
         ET.SubElement(contrato, "numPersonas").text = str(people)
     else:
         ET.SubElement(contrato, "numPersonas").text = str(
-            reservation.adults + reservation.children if reservation.children else 0
+            reservation.adults + (reservation.children or 0)
         )
     _ses_xml_payment_elements(contrato, reservation)
 


### PR DESCRIPTION
### Changes in `pms_l10n_es` module:

* **Field removal in `_checkin_mandatory_fields`:**
  - Removed `document_expedition_date` from the list of mandatory fields, likely because it is no longer required in new ses api service. (`pms_l10n_es/models/pms_checkin_partner.py`, [pms_l10n_es/models/pms_checkin_partner.pyL95](diffhunk://#diff-d2994f6fbd7fbf930e0ee1be49618f164b6f428adfc3b74218d9034ac4a88380L95))

* **Refinement of conditional logic in `_ses_xml_contract_elements`:**
  - Fix the calculation of the total number of people by replacing a ternary conditional with a more concise expression using `or`. (`pms_l10n_es/wizards/traveller_report.py`, [pms_l10n_es/wizards/traveller_report.pyL82-R82](diffhunk://#diff-65641ea6a29502d51244318d17aa70912ce005b8e526ebdc782ebde5adcc89aeL82-R82))…and fix traveller report compute 'numPersonas'