### PR TITLE
[FIX]pms: delete duplication discount in service price_total

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -1290,9 +1290,7 @@ class PmsReservation(models.Model):
     @api.depends("service_ids.price_total", "services_discount")
     def _compute_price_services(self):
         for record in self:
-            record.price_services = (
-                sum(record.mapped("service_ids.price_total")) - record.services_discount
-            )
+            record.price_services = sum(record.mapped("service_ids.price_total"))
 
     @api.depends("price_services", "price_total")
     def _compute_price_room_services_set(self):


### PR DESCRIPTION
This pull request includes a single change to the `_compute_price_services` method in the `pms/models/pms_reservation.py` file. The change removes the subtraction of `services_discount` from the calculation of `price_services`, becouse service_discount is already take account in service_ids.price_total

* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L1293-R1293): Updated the `_compute_price_services` method to calculate `price_services` as the sum of `service_ids.price_total` without subtracting `services_discount`.