### PR TITLE
[IMP]pms: avoid overwrite partner name in reservation

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -1379,7 +1379,9 @@ class PmsReservation(models.Model):
             if record.partner_id and record.partner_id != record.agency_id:
                 record.partner_name = record.partner_id.name
             if (record.folio_id and not record.partner_name) or (
-                record.folio_id.partner_name != record.partner_name
+                record.folio_id
+                and record.folio_id.partner_name
+                and record.folio_id.partner_name != record.partner_name
             ):
                 record.partner_name = record.folio_id.partner_name
             elif record.agency_id and not record.partner_name:


### PR DESCRIPTION
This pull request refines the `_compute_partner_name` method in the `pms/models/pms_reservation.py` file to improve the logic for determining the `partner_name` field. The main change ensures that null or undefined values for `folio_id.partner_name` are properly handled before comparison.

Key change:

* Updated the condition in `_compute_partner_name` to include additional checks for the presence of `folio_id` and `folio_id.partner_name` before comparing it with `record.partner_name`. This prevents potential errors when `folio_id.partner_name` is null or undefined. (`[pms/models/pms_reservation.pyL1382-R1384](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L1382-R1384)`)