### PR TITLE
[IMP]16.0-constrain _check_room_class_compatibility by is_overnight

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -1837,10 +1837,9 @@ class PmsReservation(models.Model):
                             )
                         )
 
-    @api.constrains(
-        "reservation_line_ids", "reservation_line_ids.room_id", "room_type_id"
-    )
+    @api.constrains("reservation_line_ids", "room_type_id")
     def _check_room_class_compatibility(self):
+        incompatible_class = False
         for record in self:
             if (
                 record.room_type_id
@@ -1849,20 +1848,24 @@ class PmsReservation(models.Model):
             ):
                 for line in record.reservation_line_ids:
                     if (
-                        line.room_id.room_type_id.class_id
-                        != record.room_type_id.class_id
+                        line.room_id.room_type_id.class_id.overnight
+                        != record.room_type_id.class_id.overnight
                     ):
-                        raise ValidationError(
-                            _(
-                                """The room %(room)s (type: %(room_type)s) is not
-                                compatible with the room type %(record_room_type)s
-                                (type: %(record_room_class)s)""",
-                                room=line.room_id.name,
-                                room_type=line.room_id.room_type_id.class_id.name,
-                                record_room_type=record.room_type_id.name,
-                                record_room_class=record.room_type_id.class_id.name,
-                            )
-                        )
+                        incompatible_class = line.room_id.room_type_id.class_id.name
+        if incompatible_class:
+            raise ValidationError(
+                _(
+                    (
+                        "The '%(incompatible_class)s' is not compatible with the "
+                        "reservation type class '%(reservation_class)s'. Please select "
+                        "a compatible class room for this reservation."
+                    ),
+                    {
+                        "incompatible_class": incompatible_class,
+                        "reservation_class": record.room_type_id.class_id.name,
+                    },
+                )
+            )
 
     # Action methods
     def open_partner(self):

--- a/pms/models/pms_reservation_line.py
+++ b/pms/models/pms_reservation_line.py
@@ -660,3 +660,29 @@ class PmsReservationLine(models.Model):
             if record.pms_property_id.block_create_past_reservations:
                 if record.date < fields.Date.today():
                     raise ValidationError(_("You can't create past reservations"))
+
+    @api.constrains("room_id")
+    def _check_room_class_compatibility(self):
+        incompatible_class = False
+        for record in self:
+            if (
+                record.room_id
+                and record.reservation_id.room_type_id
+                and (
+                    record.room_id.room_type_id.class_id.overnight
+                    != record.reservation_id.room_type_id.class_id.overnight
+                )
+            ):
+                incompatible_class = True
+        if incompatible_class:
+            raise ValidationError(
+                _(
+                    "The '%(incompatible_class)s' is not compatible with the "
+                    "reservation type class '%(reservation_class)s'. Please select "
+                    "a compatible class room for this reservation."
+                )
+                % {
+                    "incompatible_class": incompatible_class,
+                    "reservation_class": record.room_id.room_type_id.class_id.name,
+                }
+            )

--- a/pms/tests/__init__.py
+++ b/pms/tests/__init__.py
@@ -38,6 +38,7 @@ from . import test_pms_wizard_split_join_swap_reservation
 from . import test_product_template
 from . import test_pms_multiproperty
 from . import test_shared_room
+from . import test_pms_reservation_line
 
 # from . import test_automated_mails
 from . import test_pms_service

--- a/pms/tests/test_pms_reservation.py
+++ b/pms/tests/test_pms_reservation.py
@@ -45,6 +45,50 @@ class TestPmsReservations(TestPms, AccountTestInvoicingCommon):
             }
         )
 
+        # Additional room type class for incompatible test
+        cls.room_type_class_day = cls.env["pms.room.type.class"].create(
+            {
+                "name": "Day Use",
+                "overnight": False,
+                "default_code": "DAY",
+            }
+        )
+        cls.room_type_class_overnight = cls.env["pms.room.type.class"].create(
+            {
+                "name": "Overnight",
+                "overnight": True,
+                "default_code": "OVN",
+            }
+        )
+
+        cls.room_type_day = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Day Room",
+                "default_code": "DAY_Test",
+                "class_id": cls.room_type_class_day.id,
+            }
+        )
+
+        cls.room_type_overnight = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Overnight Room",
+                "default_code": "OVN_Test",
+                "class_id": cls.room_type_class_overnight.id,
+            }
+        )
+
+        cls.room_day = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Day 201",
+                "room_type_id": cls.room_type_day.id,
+                "capacity": 1,
+                "extra_beds_allowed": 0,
+            }
+        )
+
         # create rooms
         cls.room1 = cls.env["pms.room"].create(
             {
@@ -3399,3 +3443,63 @@ class TestPmsReservations(TestPms, AccountTestInvoicingCommon):
             "Sale_channel_origin_id of folio must be the same as "
             "sale_channel_origin of rservation",
         )
+
+    @freeze_time("2000-12-01")
+    def test_modify_reservation_with_compatible_overnight_classes(self):
+        """
+        Check that when modifying a reservation with compatible overnight
+        classes, the reservation is modified correctly.
+        """
+        # ARRANGE
+        checkin = fields.date.today()
+        checkout = fields.date.today() + datetime.timedelta(days=3)
+        reservation_vals = {
+            "checkin": checkin,
+            "checkout": checkout,
+            "room_type_id": self.room_type_double.id,
+            "partner_id": self.partner1.id,
+            "pms_property_id": self.pms_property1.id,
+            "sale_channel_origin_id": self.sale_channel_direct.id,
+        }
+        reservation = self.env["pms.reservation"].create(reservation_vals)
+
+        # ACT
+        reservation.write(
+            {
+                "room_type_id": self.room_type_overnight.id,
+            }
+        )
+
+        # ASSERT
+        self.assertEqual(
+            reservation.room_type_id.id,
+            self.room_type_overnight.id,
+            "The reservation should be modified with the new room type",
+        )
+
+    @freeze_time("2000-12-01")
+    def test_modify_reservation_with_incompatible_overnight_classes(self):
+        """
+        Check that when modifying a reservation with incompatible overnight
+        classes, the reservation raises an error.
+        """
+        # ARRANGE
+        checkin = fields.date.today()
+        checkout = fields.date.today() + datetime.timedelta(days=3)
+        reservation_vals = {
+            "checkin": checkin,
+            "checkout": checkout,
+            "room_type_id": self.room_type_double.id,
+            "partner_id": self.partner1.id,
+            "pms_property_id": self.pms_property1.id,
+            "sale_channel_origin_id": self.sale_channel_direct.id,
+        }
+        reservation = self.env["pms.reservation"].create(reservation_vals)
+
+        # ACT & ASSERT
+        with self.assertRaises(ValidationError):
+            reservation.write(
+                {
+                    "room_type_id": self.room_type_day.id,
+                }
+            )

--- a/pms/tests/test_pms_reservation_line.py
+++ b/pms/tests/test_pms_reservation_line.py
@@ -1,0 +1,225 @@
+import datetime
+
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+from .common import TestPms
+
+
+@tagged("post_install", "-at_install")
+class TestPmsReservationLines(TestPms):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        user = cls.env["res.users"].browse(1)
+        cls.env = cls.env(user=user)
+        # create a room type availability
+        cls.room_type_availability = cls.env["pms.availability.plan"].create(
+            {
+                "name": "Availability plan for TEST",
+                "pms_pricelist_ids": [(6, 0, [cls.pricelist1.id])],
+            }
+        )
+
+        # create room type
+        cls.room_type_double = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Double Test",
+                "default_code": "DBL_Test",
+                "class_id": cls.room_type_class1.id,
+            }
+        )
+
+        cls.room_type_triple = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Triple Test",
+                "default_code": "TRP_Test",
+                "class_id": cls.room_type_class1.id,
+            }
+        )
+
+        # Additional room type class for incompatible test
+        cls.room_type_class_day = cls.env["pms.room.type.class"].create(
+            {
+                "name": "Day Use",
+                "overnight": False,
+                "default_code": "DAY",
+            }
+        )
+        cls.room_type_class_overnight = cls.env["pms.room.type.class"].create(
+            {
+                "name": "Overnight",
+                "overnight": True,
+                "default_code": "OVN",
+            }
+        )
+
+        cls.room_type_day = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Day Room",
+                "default_code": "DAY_Test",
+                "class_id": cls.room_type_class_day.id,
+            }
+        )
+
+        cls.room_type_overnight = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Overnight Room",
+                "default_code": "OVN_Test",
+                "class_id": cls.room_type_class_overnight.id,
+            }
+        )
+
+        cls.room_day = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Day 201",
+                "room_type_id": cls.room_type_day.id,
+                "capacity": 1,
+                "extra_beds_allowed": 0,
+            }
+        )
+        cls.room_overnight = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Overnight 202",
+                "room_type_id": cls.room_type_overnight.id,
+                "capacity": 1,
+                "extra_beds_allowed": 0,
+            }
+        )
+
+        # create rooms
+        cls.room1 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Double 101",
+                "room_type_id": cls.room_type_double.id,
+                "capacity": 2,
+                "extra_beds_allowed": 1,
+            }
+        )
+
+        cls.room2 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Double 102",
+                "room_type_id": cls.room_type_double.id,
+                "capacity": 2,
+                "extra_beds_allowed": 1,
+            }
+        )
+
+        cls.room3 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Double 103",
+                "room_type_id": cls.room_type_double.id,
+                "capacity": 2,
+                "extra_beds_allowed": 1,
+            }
+        )
+
+        cls.room4 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Triple 104",
+                "room_type_id": cls.room_type_triple.id,
+                "capacity": 3,
+                "extra_beds_allowed": 1,
+            }
+        )
+        cls.partner1 = cls.env["res.partner"].create(
+            {
+                "firstname": "Jaime",
+                "lastname": "García",
+                "email": "jaime@example.com",
+                "birthdate_date": "1983-03-01",
+                "gender": "male",
+            }
+        )
+        cls.id_category = cls.env["res.partner.id_category"].create(
+            {"name": "DNI", "code": "D"}
+        )
+        cls.sale_channel_direct = cls.env["pms.sale.channel"].create(
+            {"name": "sale channel direct", "channel_type": "direct"}
+        )
+        cls.sale_channel1 = cls.env["pms.sale.channel"].create(
+            {"name": "saleChannel1", "channel_type": "indirect"}
+        )
+        cls.agency1 = cls.env["res.partner"].create(
+            {
+                "firstname": "partner1",
+                "is_agency": True,
+                "invoice_to_agency": "always",
+                "default_commission": 15,
+                "sale_channel_id": cls.sale_channel1.id,
+            }
+        )
+
+    @freeze_time("2000-12-01")
+    def test_modify_reservation_line_with_compatible_overnight_classes(self):
+        """
+        Check that when modifying a reservation with compatible overnight
+        classes, the reservation is modified correctly.
+        """
+        # ARRANGE
+        checkin = fields.date.today()
+        checkout = fields.date.today() + datetime.timedelta(days=3)
+        reservation_vals = {
+            "checkin": checkin,
+            "checkout": checkout,
+            "room_type_id": self.room_type_double.id,
+            "partner_id": self.partner1.id,
+            "pms_property_id": self.pms_property1.id,
+            "sale_channel_origin_id": self.sale_channel_direct.id,
+        }
+        reservation = self.env["pms.reservation"].create(reservation_vals)
+
+        # ACT
+        reservation.reservation_line_ids[0].write(
+            {
+                "room_id": self.room_overnight.id,
+            }
+        )
+
+        # ASSERT
+        self.assertEqual(
+            reservation.reservation_line_ids[0].room_id.room_type_id.id,
+            self.room_type_overnight.id,
+            "The reservation should be modified with the new room type",
+        )
+
+    @freeze_time("2000-12-01")
+    def test_modify_reservation_with_incompatible_overnight_classes(self):
+        """
+        Check that when modifying a reservation with incompatible overnight
+        classes, the reservation raises an error.
+        """
+        # ARRANGE
+        checkin = fields.date.today()
+        checkout = fields.date.today() + datetime.timedelta(days=3)
+        reservation_vals = {
+            "checkin": checkin,
+            "checkout": checkout,
+            "room_type_id": self.room_type_double.id,
+            "partner_id": self.partner1.id,
+            "pms_property_id": self.pms_property1.id,
+            "sale_channel_origin_id": self.sale_channel_direct.id,
+        }
+        reservation = self.env["pms.reservation"].create(reservation_vals)
+
+        # ACT & ASSERT
+        with self.assertRaises(ValidationError):
+            reservation.reservation_line_ids[0].write(
+                {
+                    "room_id": self.room_day.id,
+                }
+            )


### PR DESCRIPTION
This pull request refines the room compatibility validation logic in the `pms/models/pms_reservation.py` file. It introduces a more specific validation mechanism for room type compatibility based on the `is_overnight` attribute and improves error messaging for better clarity.

### Validation logic improvements:

* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L1852-R1868): Updated the `_check_room_class_compatibility` method to validate room compatibility using the `is_overnight` attribute instead of direct class comparison. This ensures compatibility checks are more precise.
* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102R1844): Added an `incompatible_class` variable to track the name of the incompatible class, enabling more descriptive error messages.

### Enhanced error messaging:

* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L1852-R1868): Improved the `ValidationError` message to clearly specify the incompatible class name and the expected reservation type class, making it easier for users to identify and resolve issues.