### PR TITLE
[IMP]16.0-pms: Touristic service set like per_day = False

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2616,7 +2616,7 @@ class PmsReservation(models.Model):
                             "folio_id": self.folio_id.id,
                             "product_id": product.id,
                             "name": product.name,
-                            "per_day": True,
+                            "per_day": False,
                             "service_line_ids": [(0, 0, line) for line in new_lines],
                         },
                     )


### PR DESCRIPTION
This pull request includes a single change to the `_build_service_commands` method in the `pms_reservation.py` file. The change modifies the `per_day` attribute in the service command dictionary from `True` to `False`.

* [`pms/models/pms_reservation.py`](diffhunk://#diff-e96472f1fd0dd13e1591c02ba4def64dd02897d7be07db449840c9601ee2c102L2619-R2619): Updated the `per_day` attribute in the `_build_service_commands` method to `False`, likely to adjust the behavior of services being created.