### PR TITLE
[IMP]pms: Avoid create invoices without product lines

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -609,6 +609,10 @@ class PmsFolio(models.Model):
             folio_lines_to_invoice = folio.sale_line_ids.filtered(
                 lambda r: r.id in list(lines_to_invoice.keys())
             )
+            # Avoid create invoices without invoicing lines
+            # (display_type is False)
+            if not folio_lines_to_invoice.filtered(lambda r: not r.display_type):
+                continue
             groups_invoice_lines = folio._get_groups_invoice_lines(
                 lines_to_invoice=folio_lines_to_invoice,
                 partner_invoice_id=partner_invoice_id,


### PR DESCRIPTION
This pull request introduces a safeguard in the `get_invoice_vals_list` method of the `pms_folio.py` file to prevent the creation of invoices without valid invoicing lines. This ensures better data integrity and avoids unnecessary invoice creation.

### Key change:
* **Validation for invoicing lines**:
  - Added a check to skip processing if no valid invoicing lines (lines with `display_type` set to `False`) are present in `folio_lines_to_invoice`. This prevents the creation of invoices with no meaningful content. (`[pms/models/pms_folio.pyR612-R615](diffhunk://#diff-fb770f511eb53a835c18fb8970e4be51ac0a7091ab13a6d086167fd6b9c079c7R612-R615)`)