### PR TITLE
[FIX]pms: Remove note creation in folio sale lines if the name is the same

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -2318,10 +2318,18 @@ class PmsFolio(models.Model):
             old_note = reservation.sale_line_ids.filtered(
                 lambda x: x.auto_reservation_note
             )
-            if old_note:
-                sale_reservation_vals.append((2, old_note.id))
             note_vals = self._get_reservation_note_vals(reservation, sequence)
-            if note_vals:
+            create_note = True
+            if old_note:
+                if (
+                    not note_vals
+                    or old_note.name != note_vals[2]["name"]
+                    or old_note.reservation_id.id != note_vals[2]["reservation_id"]
+                ):
+                    sale_reservation_vals.append((2, old_note.id))
+                else:
+                    create_note = False
+            if note_vals and create_note:
                 sale_reservation_vals.append(note_vals)
         expected_reservation_lines = self.env["pms.reservation.line"].read_group(
             [


### PR DESCRIPTION
Without this change, the note line is recreated after entering in the compute, this cause some problems when the compute is called various times with the _flush method.