### PR TITLE
[16.0][REF] replace res.partner computes with inverse function in checkin.partner

### DIFF
--- a/pms/models/pms_checkin_partner.py
+++ b/pms/models/pms_checkin_partner.py
@@ -65,18 +65,21 @@ class PmsCheckinPartner(models.Model):
         readonly=False,
         store=True,
         compute="_compute_email",
+        inverse=lambda r: r._inverse_partner_fields("email", "email"),
     )
     mobile = fields.Char(
         help="Checkin Partner Mobile",
         readonly=False,
         store=True,
         compute="_compute_mobile",
+        inverse=lambda r: r._inverse_partner_fields("mobile", "mobile"),
     )
     phone = fields.Char(
         help="Checkin Partner Phone",
         readonly=False,
         store=True,
         compute="_compute_phone",
+        inverse=lambda r: r._inverse_partner_fields("phone", "phone"),
     )
     image_128 = fields.Image(
         string="Image",
@@ -130,6 +133,7 @@ class PmsCheckinPartner(models.Model):
         store=True,
         compute="_compute_gender",
         selection=[("male", "Male"), ("female", "Female"), ("other", "Other")],
+        inverse=lambda r: r._inverse_partner_fields("gender", "gender"),
     )
     nationality_id = fields.Many2one(
         string="Nationality",
@@ -139,6 +143,7 @@ class PmsCheckinPartner(models.Model):
         index=True,
         compute="_compute_nationality_id",
         comodel_name="res.country",
+        inverse=lambda r: r._inverse_partner_fields("nationality_id", "nationality_id"),
     )
     residence_street = fields.Char(
         string="Street",
@@ -194,6 +199,7 @@ class PmsCheckinPartner(models.Model):
         readonly=False,
         store=True,
         compute="_compute_firstname",
+        inverse=lambda r: r._inverse_partner_fields("firstname", "firstname"),
     )
     lastname = fields.Char(
         string="Last Name",
@@ -201,6 +207,7 @@ class PmsCheckinPartner(models.Model):
         readonly=False,
         store=True,
         compute="_compute_lastname",
+        inverse=lambda r: r._inverse_partner_fields("lastname", "lastname"),
     )
     lastname2 = fields.Char(
         string="Second Last Name",
@@ -208,6 +215,7 @@ class PmsCheckinPartner(models.Model):
         readonly=False,
         store=True,
         compute="_compute_lastname2",
+        inverse=lambda r: r._inverse_partner_fields("lastname2", "lastname2"),
     )
     birthdate_date = fields.Date(
         string="Birthdate",
@@ -215,6 +223,7 @@ class PmsCheckinPartner(models.Model):
         readonly=False,
         store=True,
         compute="_compute_birth_date",
+        inverse=lambda r: r._inverse_partner_fields("birthdate_date", "birthdate_date"),
     )
     document_number = fields.Char(
         help="Host document number",
@@ -284,6 +293,11 @@ class PmsCheckinPartner(models.Model):
         help="Date and time of the signature",
         compute="_compute_sign_on",
     )
+
+    def _inverse_partner_fields(self, checkin_field_name, partner_field_name):
+        for record in self:
+            if record.partner_id:
+                record.partner_id[partner_field_name] = record[checkin_field_name]
 
     @api.depends("partner_id")
     def _compute_document_number(self):

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -871,7 +871,7 @@ class PmsReservation(models.Model):
                     reservation.reservation_line_ids = False
             reservation.check_in_out_dates()
 
-    @api.depends("board_service_room_id")
+    @api.depends("board_service_room_id", "adults", "children")
     def _compute_board_service_ids(self):
         if self.env.context.get("skip_compute_board_service_ids", False):
             return
@@ -2185,10 +2185,10 @@ class PmsReservation(models.Model):
             )
 
     def _check_services(self, vals):
-        # If we create a reservation with board service and other service at the
-        # same time, compute_service_ids dont run (compute with readonly to False), and
+        # If we create a reservation with board service, compute_service_ids dont run
+        # (compute with readonly to False), and
         # we must force it to compute the services linked with the board service:
-        if "board_service_room_id" in vals and "service_ids" in vals:
+        if "board_service_room_id" in vals:
             self._compute_board_service_ids()
 
     def get_folios_to_update_channel(self, vals):

--- a/pms/models/pms_room.py
+++ b/pms/models/pms_room.py
@@ -226,7 +226,7 @@ class PmsRoom(models.Model):
                                 "type": "other",
                                 "is_company": False,
                                 "active": True,
-                                "parent_id": record.pms_property_id.id,
+                                "parent_id": record.pms_property_id.partner_id.id,
                             }
                         )
                     )

--- a/pms/models/res_partner.py
+++ b/pms/models/res_partner.py
@@ -87,53 +87,7 @@ class ResPartner(models.Model):
         comodel_name="pms.folio",
         inverse_name="partner_id",
     )
-    gender = fields.Selection(
-        readonly=False,
-        store=True,
-        compute="_compute_gender",
-    )
-    birthdate_date = fields.Date(
-        readonly=False,
-        store=True,
-        compute="_compute_birthdate_date",
-    )
-    nationality_id = fields.Many2one(
-        readonly=False,
-        store=True,
-        index=True,
-        compute="_compute_nationality_id",
-    )
-    email = fields.Char(
-        readonly=False,
-        store=True,
-        compute="_compute_email",
-    )
-    mobile = fields.Char(
-        readonly=False,
-        store=True,
-        compute="_compute_mobile",
-    )
-    phone = fields.Char(
-        readonly=False,
-        store=True,
-        compute="_compute_phone",
-    )
-    firstname = fields.Char(
-        readonly=False,
-        store=True,
-        compute="_compute_firstname",
-    )
 
-    lastname = fields.Char(
-        readonly=False,
-        store=True,
-        compute="_compute_lastname",
-    )
-    lastname2 = fields.Char(
-        readonly=False,
-        store=True,
-        compute="_compute_lastname2",
-    )
     country_id = fields.Many2one(
         readonly=False,
         store=True,
@@ -246,67 +200,6 @@ class ResPartner(models.Model):
     )
 
     # pylint: disable=W8110
-    @api.depends("pms_checkin_partner_ids", "pms_checkin_partner_ids.gender")
-    def _compute_gender(self):
-        if hasattr(super(), "_compute_gender"):
-            super()._compute_gender()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_gender = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if last_update_gender and last_update_gender[0].gender:
-                    record.gender = last_update_gender[0].gender
-
-    # pylint: disable=W8110
-    @api.depends("pms_checkin_partner_ids", "pms_checkin_partner_ids.birthdate_date")
-    def _compute_birthdate_date(self):
-        if hasattr(super(), "_compute_birthdate_date"):
-            super()._compute_birthdate_date()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_birthdate = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if last_update_birthdate and last_update_birthdate[0].birthdate_date:
-                    record.birthdate_date = last_update_birthdate[0].birthdate_date
-
-    # pylint: disable=W8110
-    @api.depends("pms_checkin_partner_ids", "pms_checkin_partner_ids.nationality_id")
-    def _compute_nationality_id(self):
-        if hasattr(super(), "_compute_nationality_id"):
-            super()._compute_nationality_id()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_nationality = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if (
-                    last_update_nationality
-                    and last_update_nationality[0].nationality_id
-                ):
-                    record.nationality_id = last_update_nationality[0].nationality_id
-                if not record.nationality_id and record.country_id:
-                    record.nationality_id = record.country_id
-
-    # pylint: disable=W8110
-    @api.depends("pms_checkin_partner_ids", "pms_checkin_partner_ids.phone")
-    def _compute_phone(self):
-        if hasattr(super(), "_compute_phone"):
-            super()._compute_phone()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_phone = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if last_update_phone and last_update_phone[0].phone:
-                    record.phone = last_update_phone[0].phone
-
-    # pylint: disable=W8110
     @api.depends("pms_checkin_partner_ids", "pms_checkin_partner_ids.residence_street")
     def _compute_residence_street(self):
         if hasattr(super(), "_compute_residence_street"):
@@ -397,90 +290,6 @@ class ResPartner(models.Model):
                 )
                 if last_update_state and last_update_state[0].residence_state_id:
                     record.residence_state_id = last_update_state[0].residence_state_id
-
-    # pylint: disable=W8110
-    @api.depends(
-        "pms_checkin_partner_ids",
-        "pms_checkin_partner_ids.email",
-        "pms_reservation_ids",
-        "pms_reservation_ids.email",
-        "pms_folio_ids",
-        "pms_folio_ids.email",
-    )
-    def _compute_email(self):
-        if hasattr(super(), "_compute_email"):
-            super()._compute_email()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_checkin_mail = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if last_update_checkin_mail and last_update_checkin_mail[0].email:
-                    record.email = last_update_checkin_mail[0].email
-
-    # pylint: disable=W8110
-    @api.depends(
-        "pms_checkin_partner_ids",
-        "pms_checkin_partner_ids.mobile",
-        "pms_reservation_ids",
-        "pms_reservation_ids.mobile",
-        "pms_folio_ids",
-        "pms_folio_ids.mobile",
-    )
-    def _compute_mobile(self):
-        if hasattr(super(), "_compute_mobile"):
-            super()._compute_mobile()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_mobile = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if last_update_mobile and last_update_mobile[0].mobile:
-                    record.mobile = last_update_mobile[0].mobile
-
-    # pylint: disable=W8110
-    @api.depends("pms_checkin_partner_ids", "pms_checkin_partner_ids.firstname")
-    def _compute_firstname(self):
-        if hasattr(super(), "_compute_firstname"):
-            super()._compute_firstname()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_firstname = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if last_update_firstname and last_update_firstname[0].firstname:
-                    record.firstname = last_update_firstname[0].firstname
-
-    # pylint: disable=W8110
-    @api.depends("pms_checkin_partner_ids", "pms_checkin_partner_ids.lastname")
-    def _compute_lastname(self):
-        if hasattr(super(), "_compute_lastname"):
-            super()._compute_lastname()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_lastname = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if last_update_lastname and last_update_lastname[0].lastname:
-                    record.lastname = last_update_lastname[0].lastname
-
-    # pylint: disable=W8110
-    @api.depends("pms_checkin_partner_ids", "pms_checkin_partner_ids.lastname2")
-    def _compute_lastname2(self):
-        if hasattr(super(), "_compute_lastname2"):
-            super()._compute_lastname2()
-        for record in self:
-            if record.pms_checkin_partner_ids:
-                last_update_lastname2 = record.pms_checkin_partner_ids.filtered(
-                    lambda x, r=record: x.write_date
-                    == max(r.pms_checkin_partner_ids.mapped("write_date"))
-                )
-                if last_update_lastname2 and last_update_lastname2[0].lastname2:
-                    record.lastname2 = last_update_lastname2[0].lastname2
 
     # pylint: disable=W8110
     @api.depends("id_numbers")

--- a/pms/tests/test_pms_checkin_partner.py
+++ b/pms/tests/test_pms_checkin_partner.py
@@ -1556,10 +1556,12 @@ class TestPmsCheckinPartner(TestPms):
                     "The value of " + key + " is not correctly established",
                 )
 
-    def test_compute_partner_fields(self):
+    def test_compute_inverse_partner_fields(self):
         """
         Check that the computes of the checkin_partner fields related to your partner
         correctly add these fields to the checkin_partner.
+        Also check if a change in checkin_partner fields correctly
+        executes the inverse way.
         ---------------------------------------
         A reservation is created with an adult (checkin_partner) ql which is
         saved in the checkin_partner_id variable, a partner is also created with all
@@ -1624,3 +1626,22 @@ class TestPmsCheckinPartner(TestPms):
                         self.partner_id[key],
                         "The value of " + key + " is not correctly established",
                     )
+
+        checkin_partner_vals = {
+            "firstname": "Carlos",
+            "lastname": "balenzuela",
+            "lastname2": "Sota",
+            "email": "paz2@example.com",
+            "birthdate_date": datetime.date(1980, 10, 3),
+            "gender": "male",
+            "mobile": "626555444",
+            "phone": "124456789",
+        }
+        checkin_partner.write(checkin_partner_vals)
+        for key in checkin_partner_vals:
+            with self.subTest(k=key):
+                self.assertEqual(
+                    self.reservation.checkin_partner_ids[0][key],
+                    self.partner_id[key],
+                    "The value of " + key + " is not correctly established",
+                )


### PR DESCRIPTION
Until now, the checkin.partner fields that updated the related partner were done through a complex compute on the partner side with multiple depends. With this change, it becomes a simple inverse in checkin.partner.


The address related fields were not modified in this PR, it will be handled in a further PR who removes the residence address related fields.