### PR TITLE
[IMP]pms: add tourist tax property filter

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2503,7 +2503,7 @@ class PmsReservation(models.Model):
         if self.reservation_type != "normal":
             return False
         tax_products = self._get_tourist_tax_products(
-            pms_property_id=self.pms_property_id
+            pms_property_id=self.pms_property_id.id
         )
         if not tax_products:
             return []
@@ -2522,7 +2522,7 @@ class PmsReservation(models.Model):
                 ("is_tourist_tax", "=", True),
                 "|",
                 ("pms_property_ids", "=", False),
-                ("pms_property_ids", "in", pms_property_id.id),
+                ("pms_property_ids", "in", pms_property_id),
             ]
         )
 

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2502,17 +2502,29 @@ class PmsReservation(models.Model):
         self.ensure_one()
         if self.reservation_type != "normal":
             return False
-        tax_products = self._get_tourist_tax_products()
+        tax_products = self._get_tourist_tax_products(
+            pms_property_id=self.pms_property_id
+        )
         if not tax_products:
             return []
 
         nightly_dates = self._get_nightly_dates()
-        grouped_lines = self._build_grouped_tax_lines(tax_products, nightly_dates)
+        grouped_lines = self._build_grouped_tax_lines(
+            tax_products,
+            nightly_dates,
+        )
         existing_services = self._get_existing_tourist_tax_services()
         return self._build_service_commands(grouped_lines, existing_services)
 
-    def _get_tourist_tax_products(self):
-        return self.env["product.product"].search([("is_tourist_tax", "=", True)])
+    def _get_tourist_tax_products(self, pms_property_id):
+        return self.env["product.product"].search(
+            [
+                ("is_tourist_tax", "=", True),
+                "|",
+                ("pms_property_ids", "=", False),
+                ("pms_property_ids", "in", pms_property_id.id),
+            ]
+        )
 
     def _get_nightly_dates(self):
         return [


### PR DESCRIPTION
This pull request refines how tourist tax products are selected for reservations by updating the logic to consider the property associated with the reservation. The main change is to ensure that only relevant tourist tax products linked to the current property are used when computing tourist tax lines.

Enhancements to tourist tax product selection:

* Updated `_get_tourist_tax_products` to accept a `pms_property_id` parameter and filter products to those either not linked to any property or specifically linked to the current property (`pms_property_id`).
* Modified `_compute_tourist_tax_lines` to pass the current reservation's property to `_get_tourist_tax_products`, ensuring the correct products are selected.