### PR TITLE
[FIX]pms: taxes only in overnight rooms

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2500,7 +2500,7 @@ class PmsReservation(models.Model):
     def _compute_tourist_tax_lines(self):
         """Return ORM commands to sync tourist tax services on this reservation."""
         self.ensure_one()
-        if self.reservation_type != "normal":
+        if self.reservation_type != "normal" or not self.overnight_room:
             return False
         tax_products = self._get_tourist_tax_products(
             pms_property_id=self.pms_property_id.id


### PR DESCRIPTION
The update ensures that tourist tax services are only synced for reservations that are both of type "normal" and have an assigned overnight room.

* Logic Update: Modified the condition in the `_compute_tourist_tax_lines` method to also check for the presence of `overnight_room` in addition to `reservation_type == "normal"`. This prevents tourist tax computation for reservations without an overnight room (parkings, etc.)