### PR TITLE
Refact use of reservation_type to allow inherit conditions

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -791,7 +791,7 @@ class PmsFolio(models.Model):
     def _compute_sale_line_ids(self):
         for folio in self.filtered(lambda f: isinstance(f.id, int)):
             sale_lines_vals = []
-            if folio.reservation_type in ("normal", "staff"):
+            if folio.reservation_type in self._get_reservation_types_with_any_pricing():
                 sale_lines_vals_to_drop = []
                 seq = 0
                 for reservation in sorted(
@@ -802,7 +802,11 @@ class PmsFolio(models.Model):
                     # RESERVATION LINES
                     reservation_sale_lines = []
                     reservation_sale_lines_to_drop = []
-                    if reservation.reservation_line_ids:
+                    if (
+                        reservation.reservation_line_ids
+                        and folio.reservation_type
+                        in self._get_reservation_types_with_night_pricing()
+                    ):
                         (
                             reservation_sale_lines,
                             reservation_sale_lines_to_drop,
@@ -817,7 +821,11 @@ class PmsFolio(models.Model):
                     # RESERVATION SERVICES
                     service_sale_lines = []
                     service_sale_lines_to_drop = []
-                    if reservation.service_ids:
+                    if (
+                        reservation.service_ids
+                        and folio.reservation_type
+                        in self._get_reservation_types_with_service_pricing()
+                    ):
                         (
                             service_sale_lines,
                             service_sale_lines_to_drop,
@@ -861,7 +869,10 @@ class PmsFolio(models.Model):
     def _compute_pricelist_id(self):
         for folio in self:
             is_new = not folio.pricelist_id or isinstance(folio.id, models.NewId)
-            if folio.reservation_type == "out":
+            if (
+                folio.reservation_type
+                not in self._get_reservation_types_with_any_pricing()
+            ):
                 folio.pricelist_id = False
             elif len(folio.reservation_ids.pricelist_id) == 1:
                 folio.pricelist_id = folio.reservation_ids.pricelist_id
@@ -1224,7 +1235,10 @@ class PmsFolio(models.Model):
     )
     def _compute_amount(self):
         for record in self:
-            if record.reservation_type == "out":
+            if (
+                record.reservation_type
+                not in self._get_reservation_types_with_any_pricing()
+            ):
                 record.amount_total = 0
                 vals = {
                     "payment_state": "nothing_to_pay",
@@ -2765,3 +2779,31 @@ class PmsFolio(models.Model):
         when returning from customer portal."""
         self.ensure_one()
         return self.env.ref("pms.open_pms_folio1_form_tree_all")
+
+    def _get_reservation_types_with_night_pricing(self):
+        """
+        Returns reservation types that use night-based pricing
+        (e.g. per-night room price).
+        This method is meant to be extended by other modules.
+        """
+        return ("normal",)
+
+    def _get_reservation_types_with_service_pricing(self):
+        """
+        Returns reservation types that use the standard service pricing logic
+        (e.g. pms.service._get_price_unit_line).
+        This method is meant to be extended by other modules.
+        """
+        return ("normal", "staff")
+
+    def _get_reservation_types_with_any_pricing(self):
+        """
+        Returns reservation types that have any pricing rule.
+        (union of night-based and service-based types)
+        """
+        night = list(self._get_reservation_types_with_night_pricing())
+        service = list(self._get_reservation_types_with_service_pricing())
+
+        # Combine preserving order: night first, then service without duplicates
+        result = night + [t for t in service if t not in night]
+        return tuple(result)

--- a/pms/models/pms_service.py
+++ b/pms/models/pms_service.py
@@ -591,7 +591,11 @@ class PmsService(models.Model):
 
     def _get_price_unit_line(self, date=False):
         self.ensure_one()
-        if self.reservation_id.reservation_type in ("normal", "staff"):
+        Folio = self.env["pms.folio"]
+        if (
+            self.reservation_id.reservation_type
+            in Folio._get_reservation_types_with_service_pricing()
+        ):
             folio = self.folio_id
             reservation = self.reservation_id
             origin = reservation if reservation else folio

--- a/pms/tests/test_pms_folio_sale_line.py
+++ b/pms/tests/test_pms_folio_sale_line.py
@@ -1217,18 +1217,20 @@ class TestPmsFolioSaleLine(TestPms):
 
     def test_no_sale_lines_staff_reservation(self):
         """
-        Check that the sale_line_ids of a folio whose reservation
-        is of type 'staff' are created with price 0.
+        Check that the folio sale lines linked to a staff reservation
+        are not created.
+
         -----
         A reservation is created with the reservation_type field
-        with value 'staff'. Then it is verified that the
-        sale_line_ids of the folio created with the creation of
-        the reservation have price 0.
+        set to 'staff'. Then it is verified that the folio created
+        together with the reservation has no sale lines linked to
+        the reservation lines.
         """
         # ARRANGE
         self.partner1 = self.env["res.partner"].create({"name": "Alberto"})
-        checkin = fields.date.today()
-        checkout = fields.date.today() + datetime.timedelta(days=1)
+        checkin = fields.Date.today()
+        checkout = fields.Date.today() + datetime.timedelta(days=1)
+
         # ACT
         reservation = self.env["pms.reservation"].create(
             {
@@ -1243,11 +1245,23 @@ class TestPmsFolioSaleLine(TestPms):
                 "adults": 1,
             }
         )
+
+        # Sale lines of this folio that are linked to any reservation line
+        # of this reservation. Adjust the field name if it is
+        # reservation_line_id instead of reservation_line_ids.
+        sale_lines_linked = reservation.folio_id.sale_line_ids.filtered(
+            lambda line: line.reservation_line_ids
+            and any(
+                rl in reservation.reservation_line_ids
+                for rl in line.reservation_line_ids
+            )
+        )
+
         # ASSERT
-        self.assertEqual(
-            reservation.folio_id.sale_line_ids.mapped("price_unit")[0],
-            0,
-            "Staff folio sale lines should have price 0",
+        self.assertFalse(
+            sale_lines_linked,
+            "Staff reservations should not create folio sale lines linked "
+            "to reservation lines.",
         )
 
     def test_no_sale_lines_out_reservation(self):

--- a/pms/views/pms_folio_views.xml
+++ b/pms/views/pms_folio_views.xml
@@ -331,7 +331,7 @@
                             <field name="pms_property_id" />
                             <field
                                 name="pricelist_id"
-                                attrs="{'invisible': [('reservation_type', 'not in', 'normal')]}"
+                                attrs="{'invisible': [('reservation_type', '=', 'out')]}"
                             />
                             <field name="company_id" options="{'no_create': True}" />
                             <field
@@ -340,7 +340,7 @@
                             />
                             <field
                                 name="agency_id"
-                                attrs="{'invisible': [('reservation_type', 'not in', 'normal')]}"
+                                attrs="{'invisible': [('reservation_type', '=', 'out')]}"
                             />
                             <field name="sale_channel_origin_id" />
                             <field
@@ -367,7 +367,7 @@
                     <notebook colspan="4" col="1">
                         <page
                             string="Sale Lines"
-                            attrs="{'invisible':[('reservation_type', '!=', 'normal')]}"
+                            attrs="{'invisible':[('reservation_type', '=', 'out')]}"
                         >
                             <field
                                 name="sale_line_ids"

--- a/pms/views/pms_reservation_views.xml
+++ b/pms/views/pms_reservation_views.xml
@@ -425,7 +425,7 @@
                             <field
                                 name="pricelist_id"
                                 options="{'no_open':True,'no_create': True}"
-                                attrs="{'invisible': [('reservation_type', '!=', 'normal')]}"
+                                attrs="{'invisible': [('reservation_type', '=', 'out')]}"
                             />
                             <!--<field
                                 name="agency_id"
@@ -462,7 +462,7 @@
                             />
                             <field
                                 name="agency_id"
-                                attrs="{'invisible': [('reservation_type', '!=', 'normal')]}"
+                                attrs="{'invisible': [('reservation_type', '=', 'out')]}"
                             />
                             <field name="sale_channel_origin_id" />
                             <field


### PR DESCRIPTION
This pull request refactors the handling of reservation types and their pricing logic in the PMS module. The main improvement is the introduction of dedicated methods to determine which reservation types use night-based, service-based, or any pricing rules. This change centralizes and simplifies the logic, making it easier to extend and maintain. Additionally, UI visibility conditions are updated to align with the new logic, ensuring consistency between backend rules and the user interface.

**Backend logic improvements:**

* Added three new methods in `pms_folio.py`—`_get_reservation_types_with_night_pricing`, `_get_reservation_types_with_service_pricing`, and `_get_reservation_types_with_any_pricing`—to centralize and allow easy extension of reservation type pricing logic.
* Updated business logic in `pms_folio.py` methods (`_compute_sale_line_ids`, `_compute_pricelist_id`, `_compute_amount`) to use the new reservation type methods instead of hardcoded values, ensuring consistency and flexibility. [[1]](diffhunk://#diff-fb770f511eb53a835c18fb8970e4be51ac0a7091ab13a6d086167fd6b9c079c7L794-R794) [[2]](diffhunk://#diff-fb770f511eb53a835c18fb8970e4be51ac0a7091ab13a6d086167fd6b9c079c7L805-R809) [[3]](diffhunk://#diff-fb770f511eb53a835c18fb8970e4be51ac0a7091ab13a6d086167fd6b9c079c7L820-R828) [[4]](diffhunk://#diff-fb770f511eb53a835c18fb8970e4be51ac0a7091ab13a6d086167fd6b9c079c7L864-R875) [[5]](diffhunk://#diff-fb770f511eb53a835c18fb8970e4be51ac0a7091ab13a6d086167fd6b9c079c7L1227-R1241)
* Modified `_get_price_unit_line` in `pms_service.py` to use the new service pricing reservation type method, replacing hardcoded checks.

**User interface consistency:**

* Updated XML view files (`pms_folio_views.xml`, `pms_reservation_views.xml`) to adjust visibility conditions for fields and pages, now hiding elements only when `reservation_type` is `'out'`, matching the backend logic. [[1]](diffhunk://#diff-9c386bb3c1597b083165cb8b26c69012eda03708595131e48404bf3f2040fab2L334-R334) [[2]](diffhunk://#diff-9c386bb3c1597b083165cb8b26c69012eda03708595131e48404bf3f2040fab2L343-R343) [[3]](diffhunk://#diff-9c386bb3c1597b083165cb8b26c69012eda03708595131e48404bf3f2040fab2L370-R370) [[4]](diffhunk://#diff-1d47e736a50d7278907ec4b0643a8cf539b6edb776a82efe08ce42017e1456a4L428-R428) [[5]](diffhunk://#diff-1d47e736a50d7278907ec4b0643a8cf539b6edb776a82efe08ce42017e1456a4L465-R465)