### PR TITLE
[16.0][IMP]pms: Fiscal positions correctly use when invoicing a folio.

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -325,6 +325,10 @@ class PmsFolio(models.Model):
     # )
     fiscal_position_id = fields.Many2one(
         string="Fiscal Position",
+        compute="_compute_fiscal_position_id",
+        store=True,
+        readonly=False,
+        domain="[('company_id', '=', company_id)]",
         help="The fiscal position depends on the location of the client",
         comodel_name="account.fiscal.position",
         index=True,
@@ -565,6 +569,28 @@ class PmsFolio(models.Model):
         store=True,
         readonly=False,
     )
+
+    @api.depends("pms_property_id", "partner_id", "company_id")
+    def _compute_fiscal_position_id(self):
+        cache = {}
+        for folio in self:
+            if not folio.partner_id:
+                folio.fiscal_position_id = False
+                continue
+            key = (
+                folio.company_id.id,
+                folio.partner_id.id,
+                folio.pms_property_id.partner_id.id,
+            )
+            if key not in cache:
+                cache[key] = (
+                    self.env["account.fiscal.position"]
+                    .with_company(folio.company_id)
+                    ._get_fiscal_position(
+                        folio.partner_id, folio.pms_property_id.partner_id
+                    )
+                )
+            folio.fiscal_position_id = cache[key]
 
     @api.model
     def _get_lang_selection_options(self):
@@ -2120,10 +2146,7 @@ class PmsFolio(models.Model):
             "invoice_line_ids": [],
             "company_id": self.company_id.id,
             "payment_reference": self.name,
-            "fiscal_position_id": self.env["account.fiscal.position"]
-            .with_company(self.company_id.id)
-            ._get_fiscal_position(self.env["res.partner"].browse(partner_invoice_id))
-            .id,
+            "fiscal_position_id": self.fiscal_position_id.id,
         }
         return invoice_vals
 

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -1441,22 +1441,17 @@ class PmsReservation(models.Model):
                 record.checkin_partner_count = 0
                 record.checkin_partner_pending_count = 0
 
-    @api.depends("room_type_id", "partner_id")
+    @api.depends("room_type_id", "partner_id", "folio_id.fiscal_position_id")
     def _compute_tax_ids(self):
         for record in self:
             record = record.with_company(record.company_id)
-            if (
-                record.partner_id == record.company_id.partner_id
-                and record.company_id.self_billed_tax_ids
-            ):
-                record.tax_ids = record.company_id.self_billed_tax_ids
-            else:
-                product = self.env["product.product"].browse(
-                    record.room_type_id.product_id.id
-                )
-                record.tax_ids = product.taxes_id.filtered(
+            product = record.room_type_id.product_id
+            fiscal_position = record.folio_id.fiscal_position_id
+            record.tax_ids = fiscal_position.map_tax(
+                product.taxes_id.filtered(
                     lambda t, r=record: t.company_id == r.env.company
                 )
+            )
 
     @api.depends("reservation_line_ids", "reservation_line_ids.room_id")
     def _compute_rooms(self):

--- a/pms/models/pms_service.py
+++ b/pms/models/pms_service.py
@@ -232,24 +232,16 @@ class PmsService(models.Model):
             origin = record.reservation_id if record.reservation_id else record.folio_id
             record.pricelist_id = origin.pricelist_id
 
-    @api.depends("product_id", "folio_id.partner_id", "reservation_id.partner_id")
+    @api.depends("product_id", "folio_id.fiscal_position_id")
     def _compute_tax_ids(self):
         for service in self:
-            partner = (
-                service.reservation_id.partner_id
-                if service.reservation_id
-                else service.folio_id.partner_id
-            )
-            if (
-                partner == service.company_id.partner_id
-                and service.company_id.self_billed_tax_ids
-            ):
-                service.tax_ids = service.company_id.self_billed_tax_ids
-            else:
-                service.tax_ids = service.product_id.taxes_id.filtered(
+            fiscal_position = service.folio_id.fiscal_position_id
+            service.tax_ids = fiscal_position.map_tax(
+                service.product_id.taxes_id.filtered(
                     lambda r, s=service: not s.company_id
                     or r.company_id == s.company_id
                 )
+            )
 
     @api.depends("service_line_ids", "service_line_ids.day_qty")
     def _compute_product_qty(self):

--- a/pms/tests/test_pms_folio.py
+++ b/pms/tests/test_pms_folio.py
@@ -1479,3 +1479,86 @@ class TestPmsFolio(TestPms, AccountTestInvoicingCommon):
     def test_pms_folio_form_creation(self):
         folio_form = Form(self.env["pms.folio"])
         self.assertFalse(folio_form.possible_existing_customer_ids)
+
+    def test_pms_folio_fiscal_position_id(self):
+        """
+        Check that the fiscal_position_id field of the folio is correctly
+        set when a partner is assigned to the folio.
+        """
+        fiscal_position = self.env["account.fiscal.position"].create(
+            {"name": "Fiscal Position Test"}
+        )
+        partner = (
+            self.env["res.partner"]
+            .with_company(self.pms_property1.company_id)
+            .create(
+                {
+                    "name": "Fiscal Partner",
+                    "property_account_position_id": fiscal_position.id,
+                }
+            )
+        )
+        folio = self.env["pms.folio"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "partner_name": partner.name,
+                "partner_id": partner.id,
+            }
+        )
+        folio.env.invalidate_all()
+        self.assertEqual(
+            folio.fiscal_position_id.id,
+            fiscal_position.id,
+            "The fiscal_position_id of the folio was not "
+            "set correctly from the partner",
+        )
+
+    def test_pms_folio_priority_fiscal_position_property(self):
+        """
+        Check that the fiscal_position_id field of the folio
+        takes precedence from automatic assignation.
+        """
+        fiscal_position_property = self.env["account.fiscal.position"].create(
+            {"name": "Fiscal Position Property"}
+        )
+        # automatic fiscal position for US country
+        self.env["account.fiscal.position"].create(
+            {
+                "name": "Automatic Fiscal Position",
+                "auto_apply": True,
+                "country_id": self.env.ref("base.us").id,
+            }
+        )
+        pms_propert_1 = self.env["pms.property"].create(
+            {
+                "name": "Property with Fiscal Position",
+                "company_id": self.env.ref("base.main_company").id,
+            }
+        )
+        pms_propert_1.partner_id.property_account_position_id = (
+            fiscal_position_property.id
+        )
+        partner = (
+            self.env["res.partner"]
+            .with_company(pms_propert_1.company_id)
+            .create(
+                {
+                    "name": "Fiscal Partner",
+                    "country_id": self.env.ref("base.us").id,
+                }
+            )
+        )
+        folio = self.env["pms.folio"].create(
+            {
+                "pms_property_id": pms_propert_1.id,
+                "partner_name": partner.name,
+                "partner_id": partner.id,
+            }
+        )
+        folio.env.invalidate_all()
+        self.assertEqual(
+            folio.fiscal_position_id.id,
+            fiscal_position_property.id,
+            "The fiscal_position_id of the folio was not set "
+            "correctly from the property",
+        )

--- a/pms/views/pms_folio_views.xml
+++ b/pms/views/pms_folio_views.xml
@@ -532,6 +532,9 @@
                             string="Invoicing"
                             attrs="{'invisible':[('reservation_type', '!=', 'normal')]}"
                         >
+                            <group>
+                                <field name="fiscal_position_id" />
+                            </group>
                             <div
                                 class="alert alert-info"
                                 role="alert"

--- a/pms/views/pms_property_views.xml
+++ b/pms/views/pms_property_views.xml
@@ -124,6 +124,7 @@
                                 <field name="max_amount_simplified_invoice" />
                                 <field name="avoid_simplified_max_amount_downpayment" />
                                 <field name="invoice_reservation_note_template" />
+                                <field name="property_account_position_id" />
                             </group>
                         </page>
                         <page string="Email Configuration">


### PR DESCRIPTION
Until this change, fiscal positions were not taken into account. Only the taxes configured for the products were used.
With this PR, the customer fiscal position is considered, and it's possible to configure a fiscal position in the property partner to set it as the default if the customer doesn't have one. If left blank, it will use the standard auto-assignment.