### PR TITLE
[16.0][REM]pms: Remove self bill functionality.

### DIFF
--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -979,11 +979,6 @@ class PmsProperty(models.Model):
         partner = self.env["res.partner"].browse(partner_invoice_id)
         # For simplified invoices
         if (
-            self.company_id.partner_id.id == partner.id
-            and self.company_id.self_billed_journal_id
-        ):
-            return self.company_id.self_billed_journal_id
-        if (
             not partner
             or partner.id == self.env.ref("pms.various_pms_partner").id
             or (

--- a/pms/models/res_company.py
+++ b/pms/models/res_company.py
@@ -56,20 +56,3 @@ class ResCompany(models.Model):
         index=True,
         ondelete="restrict",
     )
-
-    self_billed_journal_id = fields.Many2one(
-        string="Self billed journal",
-        help="Journal used to create self billing",
-        comodel_name="account.journal",
-        index=True,
-        ondelete="restrict",
-    )
-    self_billed_tax_ids = fields.Many2many(
-        string="Self billed taxes",
-        help="Taxes used to create self billing",
-        comodel_name="account.tax",
-        relation="company_autoinvoicing_tax_rel",
-        column1="company_id",
-        column2="tax_id",
-        domain="[('company_id', '=', id)]",
-    )


### PR DESCRIPTION
Remove self billed journal and taxes.
This functionality is specific to Spanish legislation and applies to very particular cases. Self-billing taxes can still be used setting the fiscal position of the company contact.

Depends on https://github.com/OCA/pms/pull/365/files