### PR TITLE
[ADD]pms: change related by compute in checkin name

### DIFF
--- a/pms/models/pms_checkin_partner.py
+++ b/pms/models/pms_checkin_partner.py
@@ -348,16 +348,15 @@ class PmsCheckinPartner(models.Model):
                 else:
                     record.state = "precheckin"
 
-    @api.depends("partner_id", "firstname", "lastname", "lastname2")
+    @api.depends("partner_id", "firstname", "lastname")
     def _compute_name(self):
         for record in self:
-            if record.partner_id.name:
+            if record.partner_id:
                 record.name = record.partner_id.name
             else:
-                name = self.env["res.partner"]._get_computed_name(
-                    record.firstname, record.lastname, record.lastname2
+                record.name = self.env["res.partner"]._get_computed_name(
+                    record.lastname, record.firstname
                 )
-                record.name = name
 
     @api.depends("partner_id")
     def _compute_email(self):

--- a/pms/models/pms_checkin_partner.py
+++ b/pms/models/pms_checkin_partner.py
@@ -51,7 +51,11 @@ class PmsCheckinPartner(models.Model):
         comodel_name="pms.property",
         related="reservation_id.pms_property_id",
     )
-    name = fields.Char(help="Checkin partner name", related="partner_id.name")
+    name = fields.Char(
+        help="Checkin partner name",
+        compute="_compute_name",
+        store=True,
+    )
     email = fields.Char(
         string="E-mail",
         help="Checkin Partner Email",
@@ -344,11 +348,16 @@ class PmsCheckinPartner(models.Model):
                 else:
                     record.state = "precheckin"
 
-    @api.depends("partner_id")
+    @api.depends("partner_id", "firstname", "lastname", "lastname2")
     def _compute_name(self):
         for record in self:
-            if not record.name or record.partner_id.name:
+            if record.partner_id.name:
                 record.name = record.partner_id.name
+            else:
+                name = self.env["res.partner"]._get_computed_name(
+                    record.firstname, record.lastname, record.lastname2
+                )
+                record.name = name
 
     @api.depends("partner_id")
     def _compute_email(self):

--- a/pms_partner_second_lastname/models/pms_checkin_partner.py
+++ b/pms_partner_second_lastname/models/pms_checkin_partner.py
@@ -4,6 +4,16 @@ from odoo import api, fields, models
 class PmsCheckinPartner(models.Model):
     _inherit = "pms.checkin.partner"
 
+    @api.depends("lastname2")
+    def _compute_name(self):
+        res = super()._compute_name()
+        for record in self:
+            if not record.partner_id:
+                record.name = self.env["res.partner"]._get_computed_name(
+                    record.lastname, record.firstname, record.lastname2
+                )
+        return res
+
     lastname2 = fields.Char(
         string="Second Last Name",
         help="host second lastname",


### PR DESCRIPTION
This pull request refactors how the `name` field is managed for the `PmsCheckinPartner` model. Instead of being a related field, `name` is now a computed and stored field, allowing for more flexible and accurate name handling, especially when `partner_id` is not set. The computation logic has also been expanded to derive the name from first and last name fields when necessary.

Field definition and computation improvements:

* Changed the `name` field in `PmsCheckinPartner` from a related field to a computed and stored field, using the `_compute_name` method for its value.
* Updated the `_compute_name` method to depend on `partner_id`, `firstname`, `lastname`, and `lastname2`, and to compute the name from these fields if `partner_id` is not set.

ATENTION: Need review pms_l10n_es & pms_fastapi_contact_lastname2 to take account lastname2 in the compute