### PR TITLE
[16.0][FIX]pms: Fix res.users properties configuration in single company environment.

### DIFF
--- a/pms/views/res_users_views.xml
+++ b/pms/views/res_users_views.xml
@@ -5,7 +5,7 @@
         <field name="model">res.users</field>
         <field name="inherit_id" ref="base.view_users_form" />
         <field name="arch" type="xml">
-            <xpath expr="//page[@name='access_rights']/group" position="inside">
+            <xpath expr="//page[@name='access_rights']/group" position="after">
                 <group string="Multi Properties">
                     <field
                         string="Allowed Properties"


### PR DESCRIPTION
Without this change, the properties configuration section appears inside the companies section, which is only displayed when there is more than one company.