### PR TITLE
[FIX]pms: Allow to add various board services in a room with a default board service

### DIFF
--- a/pms/models/pms_board_service_room_type.py
+++ b/pms/models/pms_board_service_room_type.py
@@ -85,6 +85,8 @@ class PmsBoardServiceRoomType(models.Model):
     @api.constrains("by_default")
     def constrains_duplicated_board_default(self):
         for record in self:
+            if not record.by_default:
+                continue
             default_boards = (
                 record.pms_room_type_id.board_service_room_type_ids.filtered(
                     "by_default"

--- a/pms/tests/test_pms_room_type.py
+++ b/pms/tests/test_pms_room_type.py
@@ -843,6 +843,64 @@ class TestRoomType(TestPms):
                 }
             )
 
+    def test_room_type_board_service_by_default_constraint(self):
+        room_type = self.env["pms.room.type"].create(
+            {
+                "name": "Room Type",
+                "default_code": "Type1",
+                "pms_property_ids": self.pms_property1,
+                "class_id": self.room_type_class1.id,
+            }
+        )
+        board_service_default = self.env["pms.board.service"].create(
+            {
+                "name": "Board service 1",
+                "default_code": "c1",
+                "pms_property_ids": self.pms_property1,
+            }
+        )
+        board_service_not_default = self.env["pms.board.service"].create(
+            {
+                "name": "Board service 2",
+                "default_code": "c2",
+                "pms_property_ids": self.pms_property1,
+            }
+        )
+        board_service_second_default = self.env["pms.board.service"].create(
+            {
+                "name": "Board service 3",
+                "default_code": "c3",
+                "pms_property_ids": self.pms_property1,
+            }
+        )
+        self.env["pms.board.service.room.type"].create(
+            {
+                "pms_board_service_id": board_service_default.id,
+                "pms_room_type_id": room_type.id,
+                "pms_property_id": self.pms_property1.id,
+                "by_default": True,
+            }
+        )
+        self.env["pms.board.service.room.type"].create(
+            {
+                "pms_board_service_id": board_service_not_default.id,
+                "pms_room_type_id": room_type.id,
+                "pms_property_id": self.pms_property1.id,
+            }
+        )
+        with self.assertRaises(
+            UserError,
+            msg="Only can set one default board service",
+        ):
+            self.env["pms.board.service.room.type"].create(
+                {
+                    "pms_board_service_id": board_service_second_default.id,
+                    "pms_room_type_id": room_type.id,
+                    "pms_property_id": self.pms_property1.id,
+                    "by_default": True,
+                }
+            )
+
     def test_check_amenities_property_integrity(self):
         self.amenity1 = self.env["pms.amenity"].create(
             {"name": "Amenity", "pms_property_ids": self.pms_property1}


### PR DESCRIPTION
As described in the issue https://github.com/OCA/pms/issues/368, trying to add a second service to a room type with one that is already selected by default will fail, when it shouldn't.