### PR TITLE
[IMP]pms: Improvement in compute touristic taxes based in nº adults&c…

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2495,7 +2495,11 @@ class PmsReservation(models.Model):
     def _compute_tourist_tax_lines(self):
         """Return ORM commands to sync tourist tax services on this reservation."""
         self.ensure_one()
-        if self.reservation_type != "normal" or not self.overnight_room:
+        if (
+            self.reservation_type != "normal"
+            or not self.overnight_room
+            or self.state in ("draft", "cancel", "done")
+        ):
             return False
         tax_products = self._get_tourist_tax_products(
             pms_property_id=self.pms_property_id.id
@@ -2567,12 +2571,20 @@ class PmsReservation(models.Model):
         )
 
     def _get_applicable_guest_count(self, product):
-        return len(
+        count = len(
             self._get_guests_by_age(
                 product.tourist_tax_min_age,
                 product.tourist_tax_max_age,
             )
         )
+        # If not hosts found, consider all guests (if not min_age or max_age is set)
+        # or only adults min_age
+        if count == 0:
+            if not product.tourist_tax_min_age:
+                count = self.adults + self.children
+            else:
+                count = self.adults
+        return count
 
     def _get_product_price(self, product, quantity, night_date):
         product = product.with_context(


### PR DESCRIPTION
This pull request introduces improvements to the logic for calculating and applying tourist tax lines in the `pms_reservation` model. The changes ensure tourist taxes are only computed for valid reservation states and improve the accuracy of guest counting for tax purposes.

**Tourist tax application logic:**

* Updated `_compute_tourist_tax_lines` to skip tax calculation for reservations in `draft`, `cancel`, or `done` states, preventing unnecessary or incorrect tax lines.

**Guest counting improvements:**

* Enhanced `_get_applicable_guest_count` to fall back to counting all guests (adults + children) if no guests match the product's age criteria and no minimum age is set, or only adults if a minimum age is specified, ensuring the guest count for tourist tax is always accurate.…childrens