### PR TITLE
[16.0][FIX] pms: Use wizard partner fiscal position when creating invoices

### DIFF
--- a/pms/models/folio_sale_line.py
+++ b/pms/models/folio_sale_line.py
@@ -1039,7 +1039,7 @@ class FolioSaleLine(models.Model):
         result = super().write(values)
         return result
 
-    def _prepare_invoice_line(self, qty=False, **optional_values):
+    def _prepare_invoice_line(self, qty=False, invoice_fpos=None, **optional_values):
         """
         Prepare the dict of values to create the new invoice line for a folio sale line.
 
@@ -1048,6 +1048,11 @@ class FolioSaleLine(models.Model):
             should be added to the returned invoice line
         """
         self.ensure_one()
+        taxes = invoice_fpos.map_tax(
+            self.product_id.taxes_id.filtered(
+                lambda t, r=self.folio_id: t.company_id == r.env.company
+            )
+        )
         if self.is_downpayment:
             downpayment_invoice = self.folio_id.move_ids.filtered(
                 lambda x: x.payment_state != "reversed"
@@ -1067,7 +1072,7 @@ class FolioSaleLine(models.Model):
             "quantity": qty if qty else self.qty_to_invoice,
             "discount": self.discount,
             "price_unit": self.price_unit,
-            "tax_ids": [(6, 0, self.tax_ids.ids)],
+            "tax_ids": [(6, 0, taxes.ids)],
             # "analytic_account_id": self.folio_id.analytic_account_id.id,
             # "analytic_tag_ids": [(6, 0, self.analytic_tag_ids.ids)],
             "folio_line_ids": [(6, 0, [self.id])],

--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -647,6 +647,10 @@ class PmsFolio(models.Model):
                 invoice_vals = folio._prepare_invoice(
                     partner_invoice_id=group["partner_id"]
                 )
+                invoice_fpos_id = invoice_vals.get("fiscal_position_id")
+                invoice_fpos = self.env["account.fiscal.position"].browse(
+                    invoice_fpos_id
+                )
                 # Invoice line values (keep only necessary sections).
                 current_section_vals = None
                 invoice_lines_vals = []
@@ -654,7 +658,8 @@ class PmsFolio(models.Model):
                     if line.display_type == "line_section":
                         current_section_vals = line._prepare_invoice_line(
                             sequence=invoice_item_sequence
-                            + folio.sale_line_ids.ids.index(line.id)
+                            + folio.sale_line_ids.ids.index(line.id),
+                            invoice_fpos=invoice_fpos,
                         )
                         continue
                     if line.display_type != "line_note" and float_is_zero(
@@ -676,6 +681,7 @@ class PmsFolio(models.Model):
                             sequence=invoice_item_sequence
                             + folio.sale_line_ids.ids.index(line.id),
                             qty=lines_to_invoice[line.id],
+                            invoice_fpos=invoice_fpos,
                         )
                         invoice_lines_vals.append(prepared_line)
 
@@ -693,7 +699,8 @@ class PmsFolio(models.Model):
                         invoice_item_sequence += 1
                         invoice_down_payment_vals = down_payment._prepare_invoice_line(
                             sequence=invoice_item_sequence
-                            + folio.sale_line_ids.ids.index(down_payment.id)
+                            + folio.sale_line_ids.ids.index(down_payment.id),
+                            invoice_fpos=invoice_fpos,
                         )
                         invoice_lines_vals.append(invoice_down_payment_vals)
 
@@ -2101,6 +2108,15 @@ class PmsFolio(models.Model):
         (making sure to call super() to establish a clean extension chain).
         """
         self.ensure_one()
+        if partner_invoice_id and partner_invoice_id != self.partner_id.id:
+            partner = self.env["res.partner"].browse(partner_invoice_id)
+            fiscal_position = (
+                self.env["account.fiscal.position"]
+                .with_company(self.company_id)
+                ._get_fiscal_position(partner)
+            )
+        else:
+            fiscal_position = self.fiscal_position_id
         journal = self.pms_property_id._get_folio_default_journal(
             partner_invoice_id=partner_invoice_id,
             room_ids=self.reservation_ids.mapped("reservation_line_ids.room_id.id"),
@@ -2148,7 +2164,7 @@ class PmsFolio(models.Model):
             "invoice_line_ids": [],
             "company_id": self.company_id.id,
             "payment_reference": self.name,
-            "fiscal_position_id": self.fiscal_position_id.id,
+            "fiscal_position_id": fiscal_position.id,
         }
         return invoice_vals
 

--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -924,6 +924,7 @@ class PmsProperty(models.Model):
                             )
                             folio.sudo().message_post(body=mens)
                             raise ValidationError(mens)
+                    invoice_fpos = invoice.fiscal_position_id
                     for downpayment in downpayments.filtered(
                         lambda d, i=invoice: d.default_invoice_to == i.partner_id
                     ):
@@ -933,6 +934,7 @@ class PmsProperty(models.Model):
                         invoice_down_payment_vals = downpayment._prepare_invoice_line(
                             sequence=max(invoice.invoice_line_ids.mapped("sequence"))
                             + 1,
+                            invoice_fpos=invoice_fpos,
                         )
                         invoice.write(
                             {"invoice_line_ids": [(0, 0, invoice_down_payment_vals)]}

--- a/pms/wizards/folio_make_invoice_advance.py
+++ b/pms/wizards/folio_make_invoice_advance.py
@@ -156,15 +156,28 @@ class FolioAdvancePaymentInv(models.TransientModel):
 
     def _prepare_invoice_values(self, order, name, amount, line):
         partner_id = (
-            self.partner_invoice_id.id
-            if self.partner_invoice_id
-            else order.partner_invoice_id.id
+            self.partner_invoice_id if self.partner_invoice_id else order.partner_id
         )
+        taxes = line.tax_ids
+        if partner_id == order.partner_id:
+            fiscal_position = order.fiscal_position_id
+        else:
+            fiscal_position = (
+                self.env["account.fiscal.position"]
+                .with_company(order.company_id)
+                ._get_fiscal_position(partner_id)
+            )
+            product = line.product_id
+            taxes = fiscal_position.map_tax(
+                product.taxes_id.filtered(
+                    lambda t, r=order: t.company_id == r.env.company
+                )
+            )
         invoice_vals = {
             "ref": order.name,
             "move_type": "out_invoice",
             "journal_id": order.pms_property_id._get_folio_default_journal(
-                partner_invoice_id=partner_id,
+                partner_invoice_id=partner_id.id,
                 room_ids=order.mapped(
                     "reservation_ids.reservation_line_ids.room_id.id"
                 ),
@@ -172,14 +185,12 @@ class FolioAdvancePaymentInv(models.TransientModel):
             "invoice_origin": order.name,
             "invoice_user_id": order.user_id.id,
             "narration": order.note,
-            "partner_id": partner_id,
+            "partner_id": partner_id.id,
             "currency_id": order.pricelist_id.currency_id.id,
             "folio_ids": [(6, 0, order.ids)],
             "payment_reference": order.reference,
             "invoice_payment_term_id": order.payment_term_id.id,
-            "fiscal_position_id": self.env["res.partner"]
-            .browse(partner_id)
-            .property_account_position_id.id,
+            "fiscal_position_id": fiscal_position.id,
             # 'campaign_id': order.campaign_id.id,
             # 'medium_id': order.medium_id.id,
             # 'source_id': order.source_id.id,
@@ -193,7 +204,7 @@ class FolioAdvancePaymentInv(models.TransientModel):
                         "quantity": 1.0,
                         "product_id": self.product_id.id,
                         "product_uom_id": line.product_uom.id,
-                        "tax_ids": [(6, 0, line.tax_ids.ids)],
+                        "tax_ids": [(6, 0, taxes.ids)],
                         "folio_line_ids": [(6, 0, [line.id])],
                         # "analytic_tag_ids": [(6, 0, line.analytic_tag_ids.ids)],
                         # "analytic_account_id": order.analytic_account_id.id or False,
@@ -213,8 +224,6 @@ class FolioAdvancePaymentInv(models.TransientModel):
         amount, name = self._get_advance_details(order)
 
         invoice_vals = self._prepare_invoice_values(order, name, amount, line)
-        if order.fiscal_position_id:
-            invoice_vals["fiscal_position_id"] = order.fiscal_position_id.id
         invoice = (
             self.env["account.move"].sudo().create(invoice_vals).with_user(self.env.uid)
         )


### PR DESCRIPTION
With the new approach that allows setting a fiscal position on the folio, an issue occurs when a different partner is selected in the invoice creation wizard: the folio fiscal position is incorrectly applied to the invoice.

This change ensures that the invoice uses the selected partner's fiscal position and taxes when it differs from the folio partner.