### PR TITLE
[IMP]pms: update tourist tax in adults/children write

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2215,6 +2215,8 @@ class PmsReservation(models.Model):
             if (
                 "checkin" in vals
                 or "checkout" in vals
+                or "adults" in vals
+                or "children" in vals
                 or "reservation_line_ids" in vals
             ):
                 tourist_tax_services_cmds = record._compute_tourist_tax_lines()


### PR DESCRIPTION
This pull request makes a small update to the `write` method in `pms_reservation.py` to ensure that changes to the number of adults or children on a reservation will also trigger a recomputation of tourist tax lines. This helps keep tourist tax calculations accurate when guest counts are updated.

- Now, updates to the `adults` or `children` fields in a reservation will cause the tourist tax lines to be recalculated, in addition to the previous triggers (`checkin`, `checkout`, and `reservation_line_ids`).