### PR TITLE
[16.0][REF]pms: move payment from journal to payment method line.

### DIFF
--- a/pms/__manifest__.py
+++ b/pms/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "PMS (Property Management System)",
     "summary": "A property management system",
-    "version": "16.0.3.8.0",
+    "version": "16.0.3.9.0",
     "development_status": "Beta",
     "category": "Generic Modules/Property Management System",
     "website": "https://github.com/OCA/pms",

--- a/pms/migrations/16.0.3.9.0/post-migration.py
+++ b/pms/migrations/16.0.3.9.0/post-migration.py
@@ -1,0 +1,22 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Copy allowed_pms_payments from journals to their inbound payment method lines
+    old_column = openupgrade.get_legacy_name("allowed_pms_payments")
+    env.cr.execute(
+        f"""
+        UPDATE account_payment_method_line apml
+        SET allowed_on_pms = TRUE
+        FROM account_journal aj
+        WHERE apml.journal_id = aj.id
+          AND aj.{old_column} = TRUE
+          AND apml.id IN (
+              SELECT apml2.id
+              FROM account_payment_method_line apml2
+              JOIN account_payment_method apm ON apm.id = apml2.payment_method_id
+              WHERE apm.payment_type = 'inbound'
+          )
+        """
+    )

--- a/pms/migrations/16.0.3.9.0/pre-migration.py
+++ b/pms/migrations/16.0.3.9.0/pre-migration.py
@@ -1,0 +1,11 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Rename old column to keep data for post-migration
+    if openupgrade.column_exists(env.cr, "account_journal", "allowed_pms_payments"):
+        openupgrade.rename_columns(
+            env.cr,
+            {"account_journal": [("allowed_pms_payments", None)]},
+        )

--- a/pms/models/__init__.py
+++ b/pms/models/__init__.py
@@ -52,3 +52,4 @@ from . import payment_provider
 from . import account_analytic_line
 from . import res_partner_category
 from . import res_country
+from . import account_payment_method_line

--- a/pms/models/account_journal.py
+++ b/pms/models/account_journal.py
@@ -16,10 +16,6 @@ class AccountJournal(models.Model):
         column2="pms_property_id",
         check_pms_properties=True,
     )
-    allowed_pms_payments = fields.Boolean(
-        string="For manual payments",
-        help="Use to pay for reservations",
-    )
     is_simplified_invoice = fields.Boolean(
         string="Simplified invoice",
         help="Use to simplified invoice",

--- a/pms/models/account_payment_method_line.py
+++ b/pms/models/account_payment_method_line.py
@@ -1,0 +1,10 @@
+from odoo import fields, models
+
+
+class AccountPaymentMethodLine(models.Model):
+    _inherit = "account.payment.method.line"
+
+    allowed_on_pms = fields.Boolean(
+        "Allowed on PMS",
+        help="Use to pay for reservations",
+    )

--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -2137,8 +2137,7 @@ class PmsFolio(models.Model):
 
     def do_payment(
         self,
-        journal,
-        receivable_account,
+        payment_method_line,
         user,
         amount,
         folio,
@@ -2154,6 +2153,7 @@ class PmsFolio(models.Model):
         type: set cash to use statement or bank to use account.payment,
         by default, use the journal type
         """
+        journal = payment_method_line.journal_id
         if not pay_type:
             pay_type = journal.type
 
@@ -2164,6 +2164,7 @@ class PmsFolio(models.Model):
             reference += ": " + ref
         vals = {
             "journal_id": journal.id,
+            "payment_method_line_id": payment_method_line.id,
             "partner_id": partner.id if partner else False,
             "amount": amount,
             "date": date or fields.Date.today(),

--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -609,7 +609,7 @@ class PmsProperty(models.Model):
         # room_ids [list] is used to filter the payment methods
         # by rooms (usefull in apartments, villas, etc)
         self.ensure_one()
-        payment_methods = self.env["account.journal"].search(
+        journals = self.env["account.journal"].search(
             [
                 ("type", "in", ["cash", "bank"]),
                 "|",
@@ -624,13 +624,14 @@ class PmsProperty(models.Model):
             ]
         )
         if room_ids:
-            payment_methods = payment_methods.filtered(
+            journals = journals.filtered(
                 lambda p: not p.room_filter_ids
-                or any([room_id in p.room_filter_ids.ids for room_id in room_ids])
+                or any(room_id in p.room_filter_ids.ids for room_id in room_ids)
             )
+        method_lines = journals.mapped("inbound_payment_method_line_ids")
         if not automatic_included:
-            payment_methods = payment_methods.filtered(lambda p: p.allowed_pms_payments)
-        return payment_methods
+            method_lines = method_lines.filtered(lambda ml: ml.allowed_on_pms)
+        return method_lines
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/pms/tests/__init__.py
+++ b/pms/tests/__init__.py
@@ -43,3 +43,4 @@ from . import test_pms_reservation_line
 # from . import test_automated_mails
 from . import test_pms_service
 from . import test_pms_tourist_tax
+from . import test_pms_payment

--- a/pms/tests/test_pms_folio.py
+++ b/pms/tests/test_pms_folio.py
@@ -58,7 +58,7 @@ class TestPmsFolio(TestPms, AccountTestInvoicingCommon):
                 ("type", "in", ["bank", "cash"]),
             ]
         )
-        journals.allowed_pms_payments = True
+        journals.inbound_payment_method_line_ids.allowed_on_pms = True
 
         # create sale channel direct
         cls.sale_channel_direct1 = cls.env["pms.sale.channel"].create(
@@ -394,12 +394,9 @@ class TestPmsFolio(TestPms, AccountTestInvoicingCommon):
 
         # ACTION
         self.env["pms.folio"].do_payment(
-            journal=self.env["account.journal"].browse(
-                reservation1.folio_id.pms_property_id._get_payment_methods().ids[0]
-            ),
-            receivable_account=self.env["account.journal"]
-            .browse(reservation1.folio_id.pms_property_id._get_payment_methods().ids[0])
-            .suspense_account_id,
+            payment_method_line=reservation1.folio_id.pms_property_id._get_payment_methods()[
+                0
+            ],
             user=self.env.user,
             amount=reservation1.folio_id.pending_amount,
             folio=reservation1.folio_id,
@@ -441,12 +438,9 @@ class TestPmsFolio(TestPms, AccountTestInvoicingCommon):
 
         # ACTION
         self.env["pms.folio"].do_payment(
-            journal=self.env["account.journal"].browse(
-                reservation1.folio_id.pms_property_id._get_payment_methods().ids[0]
-            ),
-            receivable_account=self.env["account.journal"]
-            .browse(reservation1.folio_id.pms_property_id._get_payment_methods().ids[0])
-            .suspense_account_id,
+            payment_method_line=reservation1.folio_id.pms_property_id._get_payment_methods()[
+                0
+            ],
             user=self.env.user,
             amount=reservation1.folio_id.pending_amount - left_to_pay,
             folio=reservation1.folio_id,

--- a/pms/tests/test_pms_folio_invoice.py
+++ b/pms/tests/test_pms_folio_invoice.py
@@ -147,7 +147,7 @@ class TestPmsFolioInvoice(TestPms, AccountTestInvoicingCommon):
                 ("type", "in", ["bank", "cash"]),
             ]
         )
-        journals.allowed_pms_payments = True
+        journals.inbound_payment_method_line_ids.allowed_on_pms = True
 
     def _test_invoice_full_folio(self):
         """

--- a/pms/tests/test_pms_payment.py
+++ b/pms/tests/test_pms_payment.py
@@ -1,39 +1,212 @@
+import datetime
+
 from freezegun import freeze_time
 
-from odoo.tests.common import TransactionCase
+from odoo.tests import Form, tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+
+from .common import TestPms
 
 freeze_time("2000-02-02")
 
 
-class TestPmsPayment(TransactionCase):
+@tagged("post_install", "-at_install")
+class TestPmsPayment(TestPms, AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.user = cls.env["res.users"].browse(1)
+        cls.env = cls.env(user=cls.user)
+        cls.room_type = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Double Test",
+                "default_code": "DBL_Test",
+                "class_id": cls.room_type_class1.id,
+                "list_price": 25,
+            }
+        )
+        cls.room1 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Room 101",
+                "room_type_id": cls.room_type.id,
+                "capacity": 2,
+            }
+        )
+        cls.sale_channel = cls.env["pms.sale.channel"].create(
+            {
+                "name": "Door",
+                "channel_type": "direct",
+            }
+        )
+        # Bank journal for the property
+        cls.bank_journal = cls.env["account.journal"].search(
+            [
+                ("type", "=", "bank"),
+                "|",
+                ("pms_property_ids", "in", cls.pms_property1.id),
+                "&",
+                ("pms_property_ids", "=", False),
+                ("company_id", "=", cls.pms_property1.company_id.id),
+            ],
+            limit=1,
+        )
+        if not cls.bank_journal:
+            cls.bank_journal = cls.env["account.journal"].create(
+                {
+                    "name": "Test Bank",
+                    "type": "bank",
+                    "code": "TBNK",
+                    "company_id": cls.pms_property1.company_id.id,
+                }
+            )
+        # Ensure all inbound lines are allowed on PMS
+        cls.bank_journal.inbound_payment_method_line_ids.allowed_on_pms = True
 
-    # TODO: Test allowed manual payment
-    # create a journal with allowed_pms_payments = True and
-    # check that the _get_payment_methods property method return it
+    def _create_folio_with_reservation(self):
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "checkin": datetime.date(2000, 2, 2),
+                "checkout": datetime.date(2000, 2, 4),
+                "partner_name": "Test Partner",
+                "sale_channel_origin_id": self.sale_channel.id,
+                "room_type_id": self.room_type.id,
+            }
+        )
+        return reservation.folio_id
 
-    # TODO: Test not allowed manual payment
-    # create a journal without allowed_pms_payments = True and
-    # check that the _get_payment_methods property method dont return it
+    # =========================================================================
+    # _get_payment_methods tests
+    # =========================================================================
 
-    # TODO: Test default account payment create
-    # create a bank journal, a reservation, pay the reservation
-    # with do_payment method without pay_type parameter
-    # and check that account payment was created
+    def test_get_payment_methods_returns_method_lines(self):
+        """_get_payment_methods returns account.payment.method.line records."""
+        result = self.pms_property1._get_payment_methods()
+        self.assertEqual(
+            result._name,
+            "account.payment.method.line",
+            "Should return account.payment.method.line recordset",
+        )
 
-    # TODO: Test default statement line create
-    # create a cash journal, a reservation, pay the reservation
-    # with do_payment method without pay_type parameter
-    # and check that statement line was created
+    def test_get_payment_methods_only_inbound(self):
+        """_get_payment_methods only returns inbound payment method lines."""
+        # Mark outbound lines as allowed too
+        self.bank_journal.outbound_payment_method_line_ids.allowed_on_pms = True
+        result = self.pms_property1._get_payment_methods()
+        outbound_line_ids = set(self.bank_journal.outbound_payment_method_line_ids.ids)
+        returned_ids = set(result.ids)
+        self.assertFalse(
+            returned_ids & outbound_line_ids,
+            "Outbound payment method lines should not be returned",
+        )
 
-    # TODO: Test set pay_type cash, statement line create
-    # create a bank journal, a reservation, pay the reservation
-    # with do_payment method with 'cash' pay_type parameter
-    # and check that statement line was created
+    # =========================================================================
+    # do_payment tests
+    # =========================================================================
 
-    # TODO: Test set pay_type bank, account payment create
-    # create a cash journal, a reservation, pay the reservation
-    # with do_payment method with 'bank' pay_type parameter
-    # and check that account payment was created
+    def test_do_payment_sets_payment_method_line(self):
+        """do_payment creates account.payment with correct payment_method_line_id."""
+        folio = self._create_folio_with_reservation()
+        method_line = self.pms_property1._get_payment_methods()[0]
+        payments_before = self.env["account.payment"].search(
+            [("folio_ids", "in", folio.id)]
+        )
+        self.env["pms.folio"].do_payment(
+            payment_method_line=method_line,
+            user=self.env.user,
+            amount=folio.pending_amount,
+            folio=folio,
+            partner=folio.partner_id,
+        )
+        payment = self.env["account.payment"].search(
+            [("folio_ids", "in", folio.id), ("id", "not in", payments_before.ids)]
+        )
+        self.assertEqual(
+            payment.payment_method_line_id,
+            method_line,
+            "Payment should have the payment_method_line_id used in do_payment",
+        )
+        self.assertEqual(
+            payment.journal_id,
+            method_line.journal_id,
+            "Payment journal should be derived from the payment method line",
+        )
+
+    # =========================================================================
+    # Wizard tests
+    # =========================================================================
+
+    def _create_wizard_form(self, folio):
+        wizard_form = Form(
+            self.env["wizard.payment.folio"].with_context(active_id=folio.id)
+        )
+        wizard_form.folio_id = folio
+        wizard_form.amount = folio.pending_amount
+        return wizard_form
+
+    def test_wizard_available_journal_ids(self):
+        """Wizard computes available_journal_ids from allowed method lines."""
+        folio = self._create_folio_with_reservation()
+        wizard_form = self._create_wizard_form(folio)
+        wizard_form.journal_id = self.bank_journal
+        wizard = wizard_form.save()
+        self.assertIn(
+            self.bank_journal,
+            wizard.available_journal_ids,
+            "Bank journal with allowed lines should be in available journals",
+        )
+
+    def test_wizard_method_lines_filtered_by_journal(self):
+        """Wizard computes available_payment_method_line_ids filtered by journal."""
+        folio = self._create_folio_with_reservation()
+        wizard_form = self._create_wizard_form(folio)
+        wizard_form.journal_id = self.bank_journal
+        wizard = wizard_form.save()
+        for line in wizard.available_payment_method_line_ids:
+            self.assertEqual(
+                line.journal_id,
+                self.bank_journal,
+                "All available method lines should belong to the selected journal",
+            )
+
+    def test_wizard_onchange_journal_selects_first_line(self):
+        """Onchange journal auto-selects the first available payment method line."""
+        folio = self._create_folio_with_reservation()
+        wizard_form = self._create_wizard_form(folio)
+        wizard_form.journal_id = self.bank_journal
+        wizard = wizard_form.save()
+        self.assertTrue(
+            wizard.payment_method_line_id,
+            "Onchange should auto-select a payment method line",
+        )
+        self.assertIn(
+            wizard.payment_method_line_id,
+            wizard.available_payment_method_line_ids,
+            "Auto-selected line should be among available lines",
+        )
+
+    def test_wizard_onchange_journal_clears_line_if_no_methods(self):
+        """Onchange clears payment_method_line_id when journal has no allowed lines."""
+        folio = self._create_folio_with_reservation()
+        # Create a journal with no allowed inbound lines
+        empty_journal = self.env["account.journal"].create(
+            {
+                "name": "Empty Bank",
+                "type": "bank",
+                "code": "EBNK",
+                "company_id": self.pms_property1.company_id.id,
+            }
+        )
+        empty_journal.inbound_payment_method_line_ids.allowed_on_pms = False
+        wizard_form = self._create_wizard_form(folio)
+        # First set a valid journal so the form is happy
+        wizard_form.journal_id = self.bank_journal
+        # Now switch to the empty journal
+        wizard_form.journal_id = empty_journal
+        self.assertFalse(
+            wizard_form.payment_method_line_id,
+            "Payment method line should be cleared when journal has no allowed lines",
+        )

--- a/pms/views/account_journal_views.xml
+++ b/pms/views/account_journal_views.xml
@@ -12,10 +12,18 @@
                     string="Room Types"
                     widget="many2many_tags"
                 />
-                <field
-                    name="allowed_pms_payments"
-                    attrs="{'invisible':[('type','not in',('bank', 'cash'))]}"
-                />
+            </xpath>
+            <xpath
+                expr="//field[@name='inbound_payment_method_line_ids']/tree/field[@name='name']"
+                position="after"
+            >
+                <field name="allowed_on_pms" optional="show" />
+            </xpath>
+            <xpath
+                expr="//field[@name='outbound_payment_method_line_ids']/tree/field[@name='name']"
+                position="after"
+            >
+                <field name="allowed_on_pms" optional="show" />
             </xpath>
         </field>
     </record>

--- a/pms/wizards/wizard_payment_folio.py
+++ b/pms/wizards/wizard_payment_folio.py
@@ -22,40 +22,65 @@ class WizardPaymentFolio(models.TransientModel):
         string="Services",
         comodel_name="pms.service",
     )
-    payment_method_id = fields.Many2one(
-        string="Payment Method",
+    journal_id = fields.Many2one(
+        string="Journal",
         required=True,
         comodel_name="account.journal",
-        domain="[('id', 'in', allowed_method_ids)]",
+        domain="[('id', 'in', available_journal_ids)]",
     )
-    allowed_method_ids = fields.Many2many(
-        store="True",
+    available_journal_ids = fields.Many2many(
         comodel_name="account.journal",
-        relation="allowed_payment_journal_rel",
-        column1="payment_id",
-        column2="journal_id",
-        compute="_compute_allowed_method_ids",
+        compute="_compute_available_journal_ids",
+    )
+    payment_method_line_id = fields.Many2one(
+        string="Payment Method",
+        required=True,
+        comodel_name="account.payment.method.line",
+        domain="[('id', 'in', available_payment_method_line_ids)]",
+    )
+    available_payment_method_line_ids = fields.Many2many(
+        comodel_name="account.payment.method.line",
+        compute="_compute_available_payment_method_line_ids",
     )
     amount = fields.Float(digits=("Product Price"))
     date = fields.Date(required=True, default=fields.Date.context_today)
     partner_id = fields.Many2one(string="Partner", comodel_name="res.partner")
 
-    @api.depends("folio_id")
-    def _compute_allowed_method_ids(self):
+    def _get_allowed_method_lines(self):
         self.ensure_one()
-        journal_ids = False
-        if self.folio_id:
-            journal_ids = self.folio_id.pms_property_id._get_payment_methods(
-                room_ids=self.folio_id.mapped(
-                    "reservation_ids.reservation_line_ids.room_id.id"
-                ),
-            ).ids
-        self.allowed_method_ids = journal_ids
+        if not self.folio_id:
+            return self.env["account.payment.method.line"]
+        return self.folio_id.pms_property_id._get_payment_methods(
+            room_ids=self.folio_id.mapped(
+                "reservation_ids.reservation_line_ids.room_id.id"
+            ),
+        )
+
+    @api.depends("folio_id")
+    def _compute_available_journal_ids(self):
+        for wizard in self:
+            method_lines = wizard._get_allowed_method_lines()
+            wizard.available_journal_ids = method_lines.mapped("journal_id")
+
+    @api.depends("journal_id")
+    def _compute_available_payment_method_line_ids(self):
+        for wizard in self:
+            method_lines = wizard._get_allowed_method_lines()
+            journal = wizard.journal_id
+            wizard.available_payment_method_line_ids = method_lines.filtered(
+                lambda line, j=journal: line.journal_id == j
+            )
+
+    @api.onchange("journal_id")
+    def _onchange_journal_id(self):
+        if self.available_payment_method_line_ids:
+            self.payment_method_line_id = self.available_payment_method_line_ids[0]
+        else:
+            self.payment_method_line_id = False
 
     def button_payment(self):
         self.env["pms.folio"].do_payment(
-            self.payment_method_id,
-            self.payment_method_id.suspense_account_id,
+            self.payment_method_line_id,
             self.env.user,
             self.amount,
             self.folio_id,

--- a/pms/wizards/wizard_payment_folio.xml
+++ b/pms/wizards/wizard_payment_folio.xml
@@ -7,8 +7,10 @@
             <form string="Payment">
                 <group>
                     <group>
-                        <field name="allowed_method_ids" invisible="1" />
-                        <field name="payment_method_id" widget="radio" />
+                        <field name="available_journal_ids" invisible="1" />
+                        <field name="available_payment_method_line_ids" invisible="1" />
+                        <field name="journal_id" />
+                        <field name="payment_method_line_id" />
                         <field name="amount" />
                     </group>
                     <group>


### PR DESCRIPTION
Replace allowed_pms_payments on account.journal with allowed_on_pms on account.payment.method.line, giving finer-grained control over which payment methods are available in the PMS.

Refactor do_payment() to receive a payment_method_line instead of a journal and receivable_account. Update the payment wizard to select journal first, then payment method line. Include migration scripts to preserve existing configuration.