### PR TITLE
[IMP] pms: set partner lang from folio on checkin partner creation

### DIFF
--- a/pms/models/pms_checkin_partner.py
+++ b/pms/models/pms_checkin_partner.py
@@ -389,13 +389,16 @@ class PmsCheckinPartner(models.Model):
         return False
 
     def _get_partner_create_vals(self):
-        return {
+        vals = {
             "firstname": self.firstname,
             "lastname": self.lastname,
             "gender": self.gender,
             "birthdate_date": self.birthdate_date,
             "nationality_id": self.nationality_id.id,
         }
+        if self.folio_id.lang:
+            vals["lang"] = self.folio_id.lang
+        return vals
 
     @api.depends("email", "mobile")
     def _compute_possible_existing_customer_ids(self):

--- a/pms/tests/test_pms_checkin_partner.py
+++ b/pms/tests/test_pms_checkin_partner.py
@@ -1342,3 +1342,37 @@ class TestPmsCheckinPartner(TestPms):
         self.assertEqual(partner.country_id, self.env.ref("base.us"))
         self.assertFalse(partner.street)
         self.assertFalse(partner.city)
+
+    @freeze_time("2012-01-14")
+    def test_partner_created_with_folio_lang(self):
+        """
+        When a partner is created from a checkin via set_partner_id,
+        the partner should inherit the language from the folio.
+        """
+        # ARRANGE
+        lang_es = self.env["res.lang"]._activate_lang("es_ES")
+        folio = self.reservation_1.folio_id
+        folio.lang = lang_es.code
+        checkin = self.reservation_1.checkin_partner_ids.filtered(
+            lambda c: not c.partner_id
+        )[:1]
+        checkin.write(
+            {
+                "firstname": "Juan",
+                "lastname": "Garcia",
+            }
+        )
+
+        # ACT
+        checkin.set_partner_id()
+
+        # ASSERT
+        self.assertTrue(
+            checkin.partner_id,
+            "Partner should have been created",
+        )
+        self.assertEqual(
+            checkin.partner_id.lang,
+            lang_es.code,
+            "Partner lang should match folio lang",
+        )


### PR DESCRIPTION
## Summary
- When a partner is created from a checkin via `set_partner_id`, it now inherits the language from the associated folio.
- Previously, partners created from checkins had no language set, even when the folio had one configured.

## Test plan
- [x] Added `test_partner_created_with_folio_lang` to verify the partner gets the folio's lang
- [x] Verify that when folio has no lang set, partner creation still works as before