### PR TITLE
[IMP] pms: prevent delete/cancel of past out-of-service blocks

### DIFF
--- a/pms/i18n/es.po
+++ b/pms/i18n/es.po
@@ -2346,6 +2346,20 @@ msgid "Block the creation of reservations in the past"
 msgstr ""
 
 #. module: pms
+#: model:ir.model.fields,field_description:pms.field_pms_property__block_modify_past_out_service
+msgid "Block Modify Past Out Service"
+msgstr "Bloquear modificación de bloqueos pasados"
+
+#. module: pms
+#: model:ir.model.fields,help:pms.field_pms_property__block_modify_past_out_service
+msgid ""
+"Block deletion or cancellation of out-of-service reservations with dates "
+"already in the past"
+msgstr ""
+"Bloquea el borrado o la cancelación de reservas fuera de servicio con fechas "
+"ya pasadas"
+
+#. module: pms
 #: model:ir.model.fields,field_description:pms.field_pms_reservation__blocked
 msgid "Blocked"
 msgstr ""
@@ -12396,11 +12410,58 @@ msgstr ""
 
 #. module: pms
 #. odoo-python
+#: code:addons/pms/models/pms_reservation.py:0
+#, python-format
+msgid "You cannot cancel an out-of-service block already in the past."
+msgstr "No puede cancelar un bloqueo fuera de servicio ya en el pasado."
+
+#. module: pms
+#. odoo-python
+#: code:addons/pms/models/pms_reservation.py:0
+#, python-format
+msgid ""
+"You cannot cancel an out-of-service block with past dates. You can shorten "
+"the block to release today or future days."
+msgstr ""
+"No puede cancelar un bloqueo fuera de servicio con fechas pasadas. Puede "
+"acortar el bloqueo para liberar el día de hoy o días futuros."
+
+#. module: pms
+#. odoo-python
+#: code:addons/pms/models/pms_reservation_line.py:0
+#, python-format
+msgid ""
+"You cannot delete a day of an out-of-service block that is already in the "
+"past."
+msgstr ""
+"No puede eliminar un día de un bloqueo fuera de servicio que ya está en el "
+"pasado."
+
+#. module: pms
+#. odoo-python
 #: code:addons/pms/models/folio_sale_line.py:0
 #, python-format
 msgid ""
 "You cannot delete a sale order line once a invoice has been created from it."
 msgstr ""
+
+#. module: pms
+#. odoo-python
+#: code:addons/pms/models/pms_reservation.py:0
+#, python-format
+msgid "You cannot delete an out-of-service block already in the past."
+msgstr "No puede eliminar un bloqueo fuera de servicio ya en el pasado."
+
+#. module: pms
+#. odoo-python
+#: code:addons/pms/models/pms_reservation.py:0
+#, python-format
+msgid ""
+"You cannot delete an out-of-service block with past dates. You can shorten "
+"the block to release today or future days."
+msgstr ""
+"No puede eliminar un bloqueo fuera de servicio con fechas pasadas. Puede "
+"acortar el bloqueo para liberar el día de hoy o días futuros."
 
 #. module: pms
 #: model:ir.model.constraint,message:pms.constraint_pms_room_room_property_unique

--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -212,6 +212,11 @@ class PmsProperty(models.Model):
         help="Block the creation of reservations in the past",
         default=False,
     )
+    block_modify_past_out_service = fields.Boolean(
+        help="Block deletion or cancellation of out-of-service reservations "
+        "with dates already in the past",
+        default=False,
+    )
     invoice_reservation_note_template = fields.Text(
         translate=True,
         help="""

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2341,6 +2341,7 @@ class PmsReservation(models.Model):
         return True
 
     def action_cancel(self):
+        self._check_block_modify_past_out_service_cancel()
         for record in self:
             # else state = cancel
             if not record.allowed_cancel:
@@ -2357,6 +2358,56 @@ class PmsReservation(models.Model):
                 ):
                     record.folio_id.action_cancel()
                 record.folio_id._compute_amount()
+
+    def unlink(self):
+        self._check_block_modify_past_out_service_delete()
+        return super().unlink()
+
+    def _get_past_out_service_records(self):
+        today = fields.Date.today()
+        result = []
+        for record in self:
+            if (
+                record.reservation_type != "out"
+                or not record.pms_property_id.block_modify_past_out_service
+            ):
+                continue
+            past_lines = record.reservation_line_ids.filtered(
+                lambda line: line.date < today
+            )
+            if not past_lines:
+                continue
+            has_future = bool(record.reservation_line_ids - past_lines)
+            result.append((record, has_future))
+        return result
+
+    def _check_block_modify_past_out_service_delete(self):
+        for _record, has_future in self._get_past_out_service_records():
+            if has_future:
+                raise UserError(
+                    _(
+                        "You cannot delete an out-of-service block with past "
+                        "dates. You can shorten the block to release today "
+                        "or future days."
+                    )
+                )
+            raise UserError(
+                _("You cannot delete an out-of-service block already in the past.")
+            )
+
+    def _check_block_modify_past_out_service_cancel(self):
+        for _record, has_future in self._get_past_out_service_records():
+            if has_future:
+                raise UserError(
+                    _(
+                        "You cannot cancel an out-of-service block with past "
+                        "dates. You can shorten the block to release today "
+                        "or future days."
+                    )
+                )
+            raise UserError(
+                _("You cannot cancel an out-of-service block already in the past.")
+            )
 
     def action_assign(self):
         for record in self:

--- a/pms/models/pms_reservation_line.py
+++ b/pms/models/pms_reservation_line.py
@@ -5,7 +5,7 @@ import datetime
 import logging
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -616,6 +616,22 @@ class PmsReservationLine(models.Model):
                 record.default_invoice_to = agency
             elif not record.default_invoice_to:
                 record.default_invoice_to = False
+
+    def unlink(self):
+        today = fields.Date.today()
+        for line in self:
+            if (
+                line.reservation_id.reservation_type == "out"
+                and line.pms_property_id.block_modify_past_out_service
+                and line.date < today
+            ):
+                raise UserError(
+                    _(
+                        "You cannot delete a day of an out-of-service block "
+                        "that is already in the past."
+                    )
+                )
+        return super().unlink()
 
     def write(self, vals):
         if not self.env.context.get("force_write_blocked") and (

--- a/pms/tests/test_pms_reservation.py
+++ b/pms/tests/test_pms_reservation.py
@@ -3056,6 +3056,110 @@ class TestPmsReservations(TestPms, AccountTestInvoicingCommon):
             "a closure reason.",
         )
 
+    # tests for block_modify_past_out_service flag
+
+    def _create_out_reservation(self, checkin, checkout):
+        closure_reason = self.env["room.closure.reason"].create({"name": "Out test"})
+        return self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "reservation_type": "out",
+                "closure_reason_id": closure_reason.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+
+    @freeze_time("2012-01-14")
+    def test_block_modify_past_out_service_delete_fully_past(self):
+        """Out-of-service block fully in the past cannot be deleted."""
+        self.pms_property1.block_modify_past_out_service = True
+        today = fields.date.today()
+        reservation = self._create_out_reservation(
+            today - datetime.timedelta(days=3),
+            today - datetime.timedelta(days=1),
+        )
+        with self.assertRaisesRegex(UserError, "already in the past"):
+            reservation.unlink()
+
+    @freeze_time("2012-01-14")
+    def test_block_modify_past_out_service_cancel_with_future(self):
+        """Out-of-service block with past+future days cannot be cancelled."""
+        self.pms_property1.block_modify_past_out_service = True
+        today = fields.date.today()
+        reservation = self._create_out_reservation(
+            today - datetime.timedelta(days=2),
+            today + datetime.timedelta(days=2),
+        )
+        with self.assertRaisesRegex(UserError, "shorten the block"):
+            reservation.action_cancel()
+
+    @freeze_time("2012-01-14")
+    def test_block_modify_past_out_service_unlink_past_line(self):
+        """A past day of an out-of-service block cannot be deleted."""
+        self.pms_property1.block_modify_past_out_service = True
+        today = fields.date.today()
+        reservation = self._create_out_reservation(
+            today - datetime.timedelta(days=2),
+            today + datetime.timedelta(days=2),
+        )
+        past_line = reservation.reservation_line_ids.filtered(
+            lambda line: line.date < today
+        )[:1]
+        with self.assertRaisesRegex(UserError, "already in the past"):
+            past_line.unlink()
+
+    @freeze_time("2012-01-14")
+    def test_block_modify_past_out_service_unlink_future_line(self):
+        """A future day can be removed to shorten an out-of-service block."""
+        self.pms_property1.block_modify_past_out_service = True
+        today = fields.date.today()
+        reservation = self._create_out_reservation(
+            today - datetime.timedelta(days=2),
+            today + datetime.timedelta(days=2),
+        )
+        future_lines = reservation.reservation_line_ids.filtered(
+            lambda line: line.date >= today
+        )
+        future_lines.unlink()
+        self.assertFalse(
+            reservation.reservation_line_ids.filtered(lambda line: line.date >= today),
+            "Future days of the block should have been removed.",
+        )
+
+    @freeze_time("2012-01-14")
+    def test_block_modify_past_out_service_flag_disabled(self):
+        """When the flag is disabled, past out-of-service blocks are deletable."""
+        self.pms_property1.block_modify_past_out_service = False
+        today = fields.date.today()
+        reservation = self._create_out_reservation(
+            today - datetime.timedelta(days=3),
+            today - datetime.timedelta(days=1),
+        )
+        reservation.unlink()
+        self.assertFalse(reservation.exists())
+
+    @freeze_time("2012-01-14")
+    def test_block_modify_past_out_service_non_out_unaffected(self):
+        """Non-out-of-service reservations are not affected by the flag."""
+        self.pms_property1.block_modify_past_out_service = True
+        today = fields.date.today()
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": today - datetime.timedelta(days=3),
+                "checkout": today - datetime.timedelta(days=1),
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+        reservation.unlink()
+        self.assertFalse(reservation.exists())
+
     # tests for several sale channels in reservation
     @freeze_time("2000-11-10")
     def test_reservation_sale_channel_origin_in_reservation_lines(self):

--- a/pms/views/pms_property_views.xml
+++ b/pms/views/pms_property_views.xml
@@ -77,6 +77,7 @@
                             </group>
                             <group string="Reservation">
                                 <field name="block_create_past_reservations" />
+                                <field name="block_modify_past_out_service" />
                             </group>
                             <group string="Timezone">
                                 <field name="tz" widget="timezone_mismatch" />


### PR DESCRIPTION
## Summary

Adds a per-property setting `block_modify_past_out_service` (off by default) that prevents deleting or cancelling out-of-service reservations once they contain past days.

When the flag is enabled on a property:

- **Reservation has past + future days**: deleting or cancelling the whole reservation is rejected with a message suggesting to *shorten the block to release today or future days*.
- **Reservation is fully in the past**: deleting or cancelling is rejected outright.
- **Reservation line level**: removing a single past day of an out-of-service block is also rejected — otherwise users could bypass the reservation-level check by deleting past lines one by one.

The check covers all paths that destroy or cancel an out-of-service reservation: direct `unlink`, cascade from folio deletion, `action_cancel`, and `pms.folio.action_cancel` (which iterates and calls `pms.reservation.action_cancel`).

Spanish translations included.

## Test plan

- [ ] Enable `block_modify_past_out_service` on a property.
- [ ] Create an out-of-service block fully in the past — try to delete it / cancel it → both rejected with the "already in the past" message.
- [ ] Create an out-of-service block spanning past and future — try to delete / cancel → rejected with the "shorten the block" message; shortening (removing future lines) works; removing past lines fails.
- [ ] Create an out-of-service block fully in the future → delete and cancel work normally.
- [ ] Disable the flag → all the above operations are allowed.
- [ ] A non-`out` reservation in the past is unaffected by the new check.