### PR TITLE
[16.0][ADD] pms,pms_l10n_es: res.partner.get_vat()

### DIFF
--- a/pms/__manifest__.py
+++ b/pms/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "PMS (Property Management System)",
     "summary": "A property management system",
-    "version": "16.0.4.1.0",
+    "version": "16.0.4.2.0",
     "development_status": "Beta",
     "category": "Generic Modules/Property Management System",
     "website": "https://github.com/OCA/pms",

--- a/pms/models/res_partner.py
+++ b/pms/models/res_partner.py
@@ -242,6 +242,12 @@ class ResPartner(models.Model):
         # Template to be inherited by localization modules
         return True
 
+    def get_vat(self):
+        """Return the partner VAT. Inherited by localizations to return
+        the equivalent fiscal identification when applicable."""
+        self.ensure_one()
+        return self.vat or ""
+
     @api.constrains("is_agency", "property_product_pricelist")
     def _check_agency_pricelist(self):
         if any(

--- a/pms/tests/__init__.py
+++ b/pms/tests/__init__.py
@@ -44,3 +44,4 @@ from . import test_pms_reservation_line
 from . import test_pms_service
 from . import test_pms_tourist_tax
 from . import test_pms_payment
+from . import test_res_partner

--- a/pms/tests/test_res_partner.py
+++ b/pms/tests/test_res_partner.py
@@ -1,0 +1,13 @@
+from odoo.tests import common
+
+
+class TestResPartnerGetVat(common.TransactionCase):
+    def test_get_vat_returns_vat(self):
+        partner = self.env["res.partner"].create(
+            {"name": "Partner with VAT", "vat": "ESA12345674"}
+        )
+        self.assertEqual(partner.get_vat(), "ESA12345674")
+
+    def test_get_vat_empty_when_no_vat(self):
+        partner = self.env["res.partner"].create({"name": "Partner without VAT"})
+        self.assertEqual(partner.get_vat(), "")

--- a/pms_l10n_es/__manifest__.py
+++ b/pms_l10n_es/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "PMS Spanish Adaptation",
-    "version": "16.0.2.1.0",
+    "version": "16.0.2.2.0",
     "author": "Commit [Sun], Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "application": True,

--- a/pms_l10n_es/models/res_partner.py
+++ b/pms_l10n_es/models/res_partner.py
@@ -41,3 +41,9 @@ class ResPartner(models.Model):
             elif not self.aeat_identification:
                 return False
         return True
+
+    def get_vat(self):
+        self.ensure_one()
+        if self.aeat_identification_type:
+            return self.aeat_identification or ""
+        return super().get_vat()

--- a/pms_l10n_es/tests/test_res_partner.py
+++ b/pms_l10n_es/tests/test_res_partner.py
@@ -5,6 +5,51 @@ class TestResPartner(TestPms):
     def setUp(self):
         super().setUp()
 
+    def test_get_vat_falls_back_to_vat(self):
+        """Without aeat_identification_type, get_vat() returns the VAT field."""
+        partner = self.env["res.partner"].create(
+            {"name": "VAT only", "vat": "ESA12345674"}
+        )
+        self.assertEqual(partner.get_vat(), "ESA12345674")
+
+    def test_get_vat_returns_aeat_identification(self):
+        """When aeat_identification_type is set, get_vat() returns
+        aeat_identification regardless of vat (consistent with
+        l10n_es_aeat _parse_aeat_vat_info priority)."""
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Passport guest",
+                "vat": False,
+                "aeat_identification_type": "03",
+                "aeat_identification": "X1234567",
+            }
+        )
+        self.assertEqual(partner.get_vat(), "X1234567")
+
+    def test_get_vat_aeat_wins_over_vat(self):
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Both filled",
+                "vat": "ESA12345674",
+                "aeat_identification_type": "06",
+                "aeat_identification": "OTHER-ID-1",
+            }
+        )
+        self.assertEqual(partner.get_vat(), "OTHER-ID-1")
+
+    def test_get_vat_empty_when_aeat_type_without_value(self):
+        """If aeat_identification_type is set but aeat_identification is empty,
+        get_vat() returns "" (does not fall back to vat)."""
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Type without value",
+                "vat": "ESA12345674",
+                "aeat_identification_type": "05",
+                "aeat_identification": False,
+            }
+        )
+        self.assertEqual(partner.get_vat(), "")
+
     def test_ine_code_foreign_partner(self):
         """
         The ine code for foreigners partners should match the alpha code 3


### PR DESCRIPTION
Add `res.partner.get_vat()` on `pms` returning the VAT field, with an override in `pms_l10n_es` that returns `aeat_identification` when `aeat_identification_type` is set. Mirrors the priority of `l10n_es_aeat._parse_aeat_vat_info`.

Single canonical entry point for PMS consumers (reports, exporters, FastAPI schemas) that need the partner fiscal identifier without hardcoding the VAT/AEAT dual.
