### PR TITLE
[16.0][FIX] pms: autocheckout - replace deprecated message_post subtype kwarg

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2321,7 +2321,9 @@ class PmsReservation(models.Model):
         ):
             msg = _("No checkin was made for this reservation")
             reservation.message_post(
-                subject=_("No Checkins!"), subtype="mt_comment", body=msg
+                subject=_("No Checkins!"),
+                subtype_xmlid="mail.mt_comment",
+                body=msg,
             )
         return True
 


### PR DESCRIPTION
## Summary

Fix `PmsReservation.autocheckout()` which was using the deprecated `subtype` kwarg of `message_post()`, causing the cron **Automatic No Checkout Reservations** to fail with:

```
ValueError: message_post does not support subtype parameter anymore.
Please give a valid subtype_id or subtype_xmlid value instead.
```

The `subtype` kwarg was removed in Odoo 16. It now requires either `subtype_id` (int) or `subtype_xmlid` (str).

## Change

```diff
 reservation.message_post(
-    subject=_("No Checkins!"), subtype="mt_comment", body=msg
+    subject=_("No Checkins!"),
+    subtype_xmlid="mail.mt_comment",
+    body=msg,
 )
```

Note also that the legacy `"mt_comment"` was implicitly assumed to be prefixed with `mail.`; the explicit xmlid `"mail.mt_comment"` keeps the same behavior.

## Reproduction

Trigger the `Automatic No Checkout Reservations` cron (`server_action #341` in default install) — any reservation reaching the autocheckout path without confirmed check-ins raises the ValueError instead of posting the chatter message and marking the reservation.

## Test plan
- [x] Cron stops failing in production after the fix
- [x] Chatter message "No Checkins!" appears on the affected reservation