### PR TITLE
[16.0][FIX] pms: skip cancel-by-modification reservations on confirm_all_reservations

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -1673,7 +1673,12 @@ class PmsFolio(models.Model):
         )
 
         if self.env.context.get("confirm_all_reservations"):
-            self.reservation_ids.action_confirm()
+            # Skip reservations cancelled because of a modification: re-confirming
+            # them would re-occupy the room of a superseded version of the same
+            # booking and trigger spurious availability errors.
+            self.reservation_ids.filtered(
+                lambda r: not (r.state == "cancel" and r.cancelled_reason == "modified")
+            ).action_confirm()
 
         return True
 


### PR DESCRIPTION
## Bug

`pms.folio.action_confirm()` called with `confirm_all_reservations=True` in the context unconditionally re-confirms every reservation of the folio, including those previously cancelled.

This breaks reservations cancelled because of a modification chain (`state='cancel'`, `cancelled_reason='modified'`):

- The cancelled reservation is a historical artefact of a prior version of the same booking.
- Re-confirming it re-occupies the room of the superseded version.
- The new, current version of the same booking typically targets the same room.
- `_compute_avail_id` then raises `ValidationError: There is no availability for the room type <X> on <YYYY-MM-DD>` from the still-occupying superseded line, even though the booking itself is consistent.

The flag is set today by an external channel-manager connector when re-importing a folio whose external status has been reactivated after a cancellation — exactly the case where modification chains accumulate.

## Fix

Skip reservations with `state='cancel'` AND `cancelled_reason='modified'` when iterating `reservation_ids` to call `action_confirm()`. They are leftovers from earlier versions of the same booking and must not be revived.

Other cancelled reservations (`cancelled_reason` in `late` / `intime` / `noshow` / empty) keep being re-confirmed: those represent cases where an external system cancels and later re-confirms the same booking, and the caller of `confirm_all_reservations=True` expects them to come back to life.

## Scope

`confirm_all_reservations=True` is set by exactly one caller in known downstream connectors: the channel-manager folio importer reactivating a previously cancelled folio. The blast radius is contained to that import path.

## Test plan

- [ ] Import a folio modification whose previous version is `cancel/modified` on the same property and dates — folio should re-confirm without `ValidationError`.
- [ ] Import a folio re-activation (cancel→confirm without modification) — previous `cancel/noshow` (or similar) reservation should still be reactivated.