### PR TITLE
[IMP] pms: add active field to room.closure.reason

### DIFF
--- a/pms/models/pms_room_closure_reason.py
+++ b/pms/models/pms_room_closure_reason.py
@@ -26,3 +26,9 @@ class RoomClosureReason(models.Model):
         help="Explanation of the reason for closing a room",
         translate=True,
     )
+    active = fields.Boolean(
+        default=True,
+        help="Uncheck to archive the room closure reason and hide it"
+        " from selection lists without removing the historical records"
+        " that already reference it.",
+    )

--- a/pms/views/pms_room_closure_reason_views.xml
+++ b/pms/views/pms_room_closure_reason_views.xml
@@ -6,6 +6,13 @@
         <field name="arch" type="xml">
             <form string="Room Closure Reason">
                 <sheet>
+                    <widget
+                        name="web_ribbon"
+                        title="Archived"
+                        bg_color="bg-danger"
+                        attrs="{'invisible': [('active', '=', True)]}"
+                    />
+                    <field name="active" invisible="1" />
                     <field name="name" />
                     <field name="description" />
                     <field
@@ -27,10 +34,26 @@
             </tree>
         </field>
     </record>
+    <record model="ir.ui.view" id="pms_room_closure_reason_view_search">
+        <field name="name">pms.room.closure.reason.search</field>
+        <field name="model">room.closure.reason</field>
+        <field name="arch" type="xml">
+            <search string="Room Closure Reason">
+                <field name="name" />
+                <field name="description" />
+                <filter
+                    name="inactive"
+                    string="Archived"
+                    domain="[('active', '=', False)]"
+                />
+            </search>
+        </field>
+    </record>
     <record model="ir.actions.act_window" id="open_pms_room_closure_reason_form_tree">
         <field name="name">Room Closure Reason</field>
         <field name="res_model">room.closure.reason</field>
         <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="pms_room_closure_reason_view_search" />
     </record>
     <menuitem
         name="Closure Reasons"


### PR DESCRIPTION
## Summary

- Add `active` Boolean field (default `True`) to `room.closure.reason` so reasons that are no longer in use can be archived without losing the link from historical records that already reference them.
- Show the standard \"Archived\" ribbon on the form when the record is archived.
- Add a dedicated search view with an \"Archived\" filter and wire it to the configuration menu action.

## Motivation

Operations teams cycle through closure reason catalogues fairly often (renaming, splitting categories, etc.). Without `active`, obsolete reasons stay visible in selection dropdowns forever and the only workaround is to delete them, which is not possible once historical closures reference them.

## Test plan

- [ ] Existing closure reasons are kept `active=True` after the module update (default on the new column).
- [ ] Form view shows the \"Archived\" ribbon when toggled off and hides it when active.
- [ ] The \"Archived\" filter under the dedicated menu lists archived reasons.
- [ ] Selection dropdowns on `pms.reservation` / out-of-service flows no longer include archived reasons by default.