### PR TITLE
[16.0][FIX] pms: parse availability read_group dates from __range, not the localized label

### DIFF
--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -446,9 +446,10 @@ class PmsProperty(models.Model):
                 )
                 grouped_rules = {}
                 for group in rule_groups:
-                    date = datetime.datetime.strptime(
-                        group["date:day"], "%d %b %Y"
-                    ).date()
+                    # Use ISO ``__range`` boundary: the ``date:day`` label is
+                    # locale-formatted and ``with_context(lang="en_US")`` is
+                    # ignored when ``en_US`` is not installed.
+                    date = fields.Date.from_string(group["__range"]["date:day"]["from"])
                     for rt in room_types:
                         group_avail = group["plan_avail"]
                         items = self.env["pms.availability.plan.rule"].search(


### PR DESCRIPTION
## Issue

`PmsProperty._compute_availability` groups `pms.availability.plan.rule` records by `date:day` and parses the resulting group label with `datetime.strptime(group['date:day'], '%d %b %Y')`:

https://github.com/OCA/pms/blob/16.0/pms/models/pms_property.py#L449-L451

The `with_context(lang='en_US')` chained before `read_group` does **not** guarantee an English label. Odoo formats the group label via `babel.dates.format_date` using `get_lang(env).code`, and that helper silently ignores the context language when `en_US` is not installed on the database, falling back to `env.user.company_id.partner_id.lang`:

https://github.com/OCA/OCB/blob/16.0/odoo/tools/misc.py#L1337-L1355

## Symptom

On a database where `en_US` is not installed (very common for single-language production tenants), any availability computation that goes through this branch (i.e. `pricelist.availability_plan_id` set and `real_avail=False`) raises:

```
ValueError: time data '09 jun. 2026' does not match format '%d %b %Y'
```

The format token `%b` is parsed in the C locale and only accepts English month abbreviations.

## Fix

`read_group` already exposes the date boundary in ISO format through `group['__range'][gb]['from']`. Use that instead of parsing the locale-formatted label. This removes the locale dependency entirely (the `with_context(lang='en_US')` becomes harmless either way).

## Test plan

- [ ] Existing tests pass.
- [ ] On a DB where `en_US` is **not** installed: trigger an availability computation that hits the `pricelist.availability_plan_id and not real_avail` branch. Before the fix it raises; after the fix it returns the integer count.