### PR TITLE
[FIX] pms: allow decimal values in agency commission

### DIFF
--- a/pms/__manifest__.py
+++ b/pms/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "PMS (Property Management System)",
     "summary": "A property management system",
-    "version": "16.0.4.7.0",
+    "version": "16.0.4.7.1",
     "development_status": "Beta",
     "category": "Generic Modules/Property Management System",
     "website": "https://github.com/OCA/pms",

--- a/pms/models/res_partner.py
+++ b/pms/models/res_partner.py
@@ -30,7 +30,7 @@ class ResPartner(models.Model):
         ondelete="restrict",
         index=True,
     )
-    default_commission = fields.Integer(string="Commission", help="Default commission")
+    default_commission = fields.Float(string="Commission", help="Default commission")
     commission_type = fields.Selection(
         selection=[
             ("included", "Commission Included in Price"),


### PR DESCRIPTION
## Problem

The agency `default_commission` field on `res.partner` was declared as `fields.Integer`, so any commission with a fractional part (e.g. an OTA charging **15.5%**) was truncated to its integer part when stored.

This propagates downstream:
- `pms.reservation.commission_percent` (already a `Float`) is computed directly from `agency_id.default_commission`, so it inherits the truncated value.
- `pms.reservation.commission_amount = price_total * commission_percent / 100` is therefore computed on the wrong percentage, yielding an incorrect amount to invoice.

## Fix

Declare `default_commission` as `fields.Float` so fractional commissions are preserved end to end. The partner form view renders the decimals automatically, and existing integer values are kept on update (the ORM alters the column type in place).

Existing tests set `default_commission` to integer values and recompute against the same field, so they remain valid (`15 == 15.0`).