### PR TITLE
[16.0][FIX] pms: make auto_departure_delayed idempotent

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2607,7 +2607,13 @@ class PmsReservation(models.Model):
         for reservation in reservations:
             if reservation.overnight_room:
                 if reservation.checkout == fields.Datetime.today().date():
-                    reservation.state = "departure_delayed"
+                    # Reservations already flagged on a previous run stay in the
+                    # search domain (state == "departure_delayed"). Skip the
+                    # write when the state does not change: reassigning the same
+                    # value retriggers the folio's stored amount tracking on
+                    # every cron run, flooding the chatter with empty changes.
+                    if reservation.state != "departure_delayed":
+                        reservation.state = "departure_delayed"
                 else:
                     reservation.autocheckout(reservation)
             else:

--- a/pms/tests/test_pms_checkin_partner.py
+++ b/pms/tests/test_pms_checkin_partner.py
@@ -613,6 +613,54 @@ class TestPmsCheckinPartner(TestPms):
             "Reservations not set like Departure delayed",
         )
 
+    @freeze_time("2012-01-14")
+    def test_auto_departure_delayed_idempotent(self):
+        """
+        A reservation already flagged as 'departure_delayed' on its checkout
+        day stays in auto_departure_delayed's search domain. A second cron run
+        must not rewrite its state again: a no-op rewrite bumps write_date and
+        retriggers the folio's stored amount tracking, flooding the chatter
+        with empty changes (untaxed amount logged as 0.0 -> 0.0). The method
+        must be idempotent.
+        """
+
+        # ARRANGE
+        self.reservation_1.write(
+            {
+                "checkin": datetime.date.today(),
+                "checkout": datetime.date.today() + datetime.timedelta(days=3),
+                "adults": 1,
+            }
+        )
+        PmsReservation = self.env["pms.reservation"]
+        self.checkin1.action_on_board()
+
+        # ACTION 1: first cron run on the checkout day, the onboard reservation
+        # transitions to departure_delayed (a real state change).
+        with freeze_time("2012-01-17 12:00:00"):
+            PmsReservation.auto_departure_delayed()
+        self.assertEqual(
+            self.reservation_1.state,
+            "departure_delayed",
+            "Reservations not set like Departure delayed",
+        )
+        write_date_after_first_run = self.reservation_1.write_date
+
+        # ACTION 2: a later cron run on the same checkout day, over the already
+        # flagged reservation.
+        with freeze_time("2012-01-17 13:00:00"):
+            PmsReservation.auto_departure_delayed()
+
+        # ASSERT: the reservation must not be written again (idempotent). A
+        # no-op rewrite would bump write_date and retrigger the folio amount
+        # tracking, flooding the chatter with empty changes.
+        self.assertEqual(
+            self.reservation_1.write_date,
+            write_date_after_first_run,
+            "auto_departure_delayed is not idempotent: a second run rewrote "
+            "an already departure_delayed reservation",
+        )
+
     # REVIEW: Redesing constrains mobile&mail control
     # @freeze_time("2010-12-10")
     # def test_not_valid_emails(self):


### PR DESCRIPTION
## Problem

The *No checkout* cron (`pms.reservation.auto_departure_delayed`, scheduled every 5 minutes) selects reservations in state `onboard` / `departure_delayed` whose checkout date has passed:

```python
reservations = self.env["pms.reservation"].search([
    ("state", "in", ("onboard", "departure_delayed")),
    ("checkout", "<=", fields.Datetime.today().date()),
])
for reservation in reservations:
    if reservation.overnight_room:
        if reservation.checkout == fields.Datetime.today().date():
            reservation.state = "departure_delayed"
        ...
```

On the checkout day itself, an overnight reservation that was already flagged as `departure_delayed` on a previous run **stays inside the search domain**. Each run then reassigns `state = "departure_delayed"` to a record that already holds that value.

That no-op write forces a recompute of the folio's stored, tracked `amount_untaxed` field. The mail tracking framework reacts by posting an **empty change** to the folio chatter (untaxed amount logged as `0.0 -> 0.0`) on **every** cron run — roughly one bogus message every 5 minutes — for the whole checkout day, until the date rolls over and the reservation is auto-checked-out. Affected folios accumulate dozens of meaningless tracking notes authored by the cron user.

## Fix

Skip the write when the state does not change, so `auto_departure_delayed` is idempotent and no longer floods the chatter:

```python
if reservation.state != "departure_delayed":
    reservation.state = "departure_delayed"
```

## Test

Added `test_auto_departure_delayed_idempotent`: it runs the cron twice on the checkout day and asserts that the second run (over an already `departure_delayed` reservation) generates no new chatter message on the folio.
