### PR TITLE
[16.0][FIX] pms: do not auto-assign archived rooms

### DIFF
--- a/pms/models/pms_reservation_line.py
+++ b/pms/models/pms_reservation_line.py
@@ -363,8 +363,8 @@ class PmsReservationLine(models.Model):
                 ):
                     if self.env.context.get("force_overbooking"):
                         line.room_id = reservation.room_type_id.room_ids.filtered(
-                            lambda r, line=line: r.pms_property_id
-                            == line.pms_property_id
+                            lambda r, line=line: r.active
+                            and r.pms_property_id == line.pms_property_id
                         )[0]
                     else:
                         raise ValidationError(
@@ -377,11 +377,22 @@ class PmsReservationLine(models.Model):
                     rooms_ranking = dict()
 
                     # we go through the rooms of the type
-                    for room in self.env["pms.room"].search(
-                        [
-                            ("room_type_id", "=", reservation.room_type_id.id),
-                            ("pms_property_id", "=", reservation.pms_property_id.id),
-                        ]
+                    # (force active_test to avoid picking archived rooms when
+                    # the context carries active_test=False, e.g. connector
+                    # imports)
+                    for room in (
+                        self.env["pms.room"]
+                        .with_context(active_test=True)
+                        .search(
+                            [
+                                ("room_type_id", "=", reservation.room_type_id.id),
+                                (
+                                    "pms_property_id",
+                                    "=",
+                                    reservation.pms_property_id.id,
+                                ),
+                            ]
+                        )
                     ):
                         # we iterate the dates from the date of the line to the checkout
                         for date_iterator in [

--- a/pms/tests/test_pms_reservation_line.py
+++ b/pms/tests/test_pms_reservation_line.py
@@ -220,3 +220,72 @@ class TestPmsReservationLines(TestPms):
                     "room_id": self.room_day.id,
                 }
             )
+
+    @freeze_time("2000-12-01")
+    def test_no_archived_room_in_split_assignment(self):
+        """
+        Room auto-assignment must never pick archived rooms, even when
+        the environment context carries active_test=False (e.g. records
+        created from connector imports, where the binder returns records
+        with that context).
+
+        No active double room is free for the whole stay, so the
+        assignment falls back to the night-by-night ranking. An archived
+        room, having no reservation lines, always ranks best and would
+        win the ranking if not filtered out, leaving the reservation
+        assigned to a room that is invisible in the planning and does
+        not consume availability.
+        """
+        # ARRANGE
+        checkin = fields.date.today()
+        checkout = fields.date.today() + datetime.timedelta(days=2)
+        # room1 is taken the first night, room2 the second night,
+        # so no active double room is free for the entire stay
+        self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkin + datetime.timedelta(days=1),
+                "preferred_room_id": self.room1.id,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+        self.env["pms.reservation"].create(
+            {
+                "checkin": checkin + datetime.timedelta(days=1),
+                "checkout": checkout,
+                "preferred_room_id": self.room2.id,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+        self.room3.active = False
+
+        # ACT
+        reservation = (
+            self.env["pms.reservation"]
+            .with_context(active_test=False)
+            .create(
+                {
+                    "checkin": checkin,
+                    "checkout": checkout,
+                    "room_type_id": self.room_type_double.id,
+                    "partner_id": self.partner1.id,
+                    "pms_property_id": self.pms_property1.id,
+                    "sale_channel_origin_id": self.sale_channel_direct.id,
+                }
+            )
+        )
+
+        # ASSERT
+        self.assertNotIn(
+            self.room3,
+            reservation.reservation_line_ids.room_id,
+            "Archived rooms must not be auto-assigned to reservations",
+        )
+        self.assertTrue(
+            all(reservation.reservation_line_ids.room_id.mapped("active")),
+            "All rooms auto-assigned to a reservation must be active",
+        )


### PR DESCRIPTION
## Problem

When a reservation is created under a context carrying `active_test=False` (e.g. records created from channel connector imports — the connector binder returns records with that context), `_compute_room_id()` can assign an **archived room**:

- The night-by-night ranking branch searches `pms.room` without forcing `active_test=True`. An archived room never has reservation lines, so it always gets the best ranking (free every night) and wins whenever no active room is free for the whole stay.
- The `force_overbooking` fallback picks the first room from `room_type_id.room_ids`, which also includes archived rooms under such a context.

The resulting reservation is **invisible in the planning** (archived rooms are not displayed) and **does not consume availability** (`get_rooms_not_avail()` only counts active rooms), so the room type keeps selling one unit more than really available — an overbooking risk.

Observed in production: a 2-room OTA booking imported while no single room of the type was free for the whole stay ended up with one reservation silently assigned to a room archived months earlier.

## Fix

Force `active_test=True` in the ranking room search and filter archived rooms out of the `force_overbooking` fallback. This completes the guards already present in `get_real_free_rooms()` and `splitted_availability()` (`pms_property.py`), which cover the full-stay branch but not these two fallback branches.

Includes a regression test reproducing the scenario (archived room would win the ranking; must be excluded and the reservation split across active rooms instead).