### PR TITLE
[16.0][IMP] pms: separate room assignment order from display order

### DIFF
--- a/pms/__manifest__.py
+++ b/pms/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "PMS (Property Management System)",
     "summary": "A property management system",
-    "version": "16.0.4.10.0",
+    "version": "16.0.4.11.0",
     "development_status": "Beta",
     "category": "Generic Modules/Property Management System",
     "website": "https://github.com/OCA/pms",

--- a/pms/migrations/16.0.4.11.0/pre-migration.py
+++ b/pms/migrations/16.0.4.11.0/pre-migration.py
@@ -1,0 +1,23 @@
+# Copyright 2026 Commit [Sun]
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Initialize assignment_sequence with the current display sequence.
+    # If the column already exists (e.g. created manually ahead of this
+    # migration), keep the values already set.
+    if not openupgrade.column_exists(env.cr, "pms_room", "assignment_sequence"):
+        env.cr.execute(
+            """
+            ALTER TABLE pms_room
+            ADD COLUMN assignment_sequence integer
+            """
+        )
+        env.cr.execute(
+            """
+            UPDATE pms_room
+            SET assignment_sequence = sequence
+            """
+        )

--- a/pms/models/pms_reservation_line.py
+++ b/pms/models/pms_reservation_line.py
@@ -348,9 +348,12 @@ class PmsReservationLine(models.Model):
                                 )
 
                     # otherwise we assign the first of those
-                    # available for the entire stay
+                    # available for the entire stay following the
+                    # room assignment order (assignment_sequence)
                     else:
-                        line.room_id = rooms_available[0]
+                        line.room_id = rooms_available.sorted(
+                            key=lambda r: (r.assignment_sequence, r.sequence, r.id)
+                        )[0]
                 # check that the reservation cannot be allocated even by dividing it
                 elif not self.env["pms.property"].splitted_availability(
                     checkin=reservation.checkin,

--- a/pms/models/pms_room.py
+++ b/pms/models/pms_room.py
@@ -28,6 +28,14 @@ class PmsRoom(models.Model):
         "Changing the position changes the sequence",
         default=0,
     )
+    assignment_sequence = fields.Integer(
+        help="Order used to automatically assign rooms on reservations "
+        "without a specific room preassigned (OTAs, web, etc.); "
+        "rooms with lower values are assigned first. "
+        "It is independent of the display order (sequence). "
+        "By default it takes the same value as the sequence.",
+        default=0,
+    )
     pms_property_id = fields.Many2one(
         string="Property",
         help="Properties with access to the element;"
@@ -352,6 +360,8 @@ class PmsRoom(models.Model):
                     vals.update({"short_name": short_name})
                 else:
                     vals.update({"short_name": vals["name"]})
+            if "assignment_sequence" not in vals and "sequence" in vals:
+                vals["assignment_sequence"] = vals["sequence"]
         records = super().create(vals_list)
         records._trigger_avail_recompute(
             records.mapped("pms_property_id").ids,

--- a/pms/tests/test_pms_reservation_line.py
+++ b/pms/tests/test_pms_reservation_line.py
@@ -195,6 +195,65 @@ class TestPmsReservationLines(TestPms):
         )
 
     @freeze_time("2000-12-01")
+    def test_auto_assignment_follows_assignment_sequence(self):
+        """
+        Check that the automatic room assignment of a reservation without
+        room preassigned follows the assignment_sequence order of the rooms
+        instead of the display order (sequence).
+        """
+        # ARRANGE
+        # Display order: room1 < room2 < room3
+        # Assignment order: room3 < room2 < room1
+        self.room1.write({"sequence": 1, "assignment_sequence": 3})
+        self.room2.write({"sequence": 2, "assignment_sequence": 2})
+        self.room3.write({"sequence": 3, "assignment_sequence": 1})
+        checkin = fields.date.today()
+        checkout = fields.date.today() + datetime.timedelta(days=3)
+
+        # ACT
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+
+        # ASSERT
+        self.assertEqual(
+            reservation.reservation_line_ids.room_id,
+            self.room3,
+            "The room with the lowest assignment_sequence should be "
+            "assigned first on reservations without room preassigned",
+        )
+
+    def test_room_assignment_sequence_defaults_to_sequence(self):
+        """
+        Check that the assignment_sequence of a new room takes the same
+        value as the sequence when it is not explicitly set.
+        """
+        # ACT
+        room = self.env["pms.room"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "name": "Double 105",
+                "room_type_id": self.room_type_double.id,
+                "capacity": 2,
+                "sequence": 7,
+            }
+        )
+
+        # ASSERT
+        self.assertEqual(
+            room.assignment_sequence,
+            7,
+            "The assignment_sequence of a new room should default " "to its sequence",
+        )
+
+    @freeze_time("2000-12-01")
     def test_modify_reservation_with_incompatible_overnight_classes(self):
         """
         Check that when modifying a reservation with incompatible overnight

--- a/pms/views/pms_room_views.xml
+++ b/pms/views/pms_room_views.xml
@@ -29,6 +29,7 @@
                     </div>
                     <group>
                         <field name="sequence" />
+                        <field name="assignment_sequence" />
                     </group>
                     <notebook>
                         <page name="information_pms_room" string="Information">
@@ -247,6 +248,7 @@
                 <field name="extra_beds_allowed" />
                 <field name="room_amenity_ids" widget="many2many_tags" />
                 <field name="short_name" />
+                <field name="assignment_sequence" optional="show" />
                 <field name="parent_id" optional="hide" />
             </tree>
         </field>


### PR DESCRIPTION
Rooms currently have a single `sequence` field that controls both the display order (room lists, plannings) and, implicitly, the automatic room assignment order: when a reservation without a specific room preassigned comes in (OTAs, web, channel managers...), the first free room by `sequence` is assigned.

This PR adds a new `assignment_sequence` field on `pms.room` so both concerns can be managed independently:

- `sequence`: display/planning order (unchanged).
- `assignment_sequence`: order used by the automatic assignment in `pms.reservation.line._compute_room_id` — the free room with the lowest value is assigned first.

Details:
- On module update, a pre-migration initializes `assignment_sequence` with the current `sequence` of each room (skipped if the column already exists), so behavior does not change until a hotel customizes it.
- New rooms default `assignment_sequence` to their `sequence` when not explicitly set.
- The field is exposed in the room form view and as an optional column in the room tree view.
- Tests added for the assignment order and the default value.