### PR TITLE
[16.0][FIX] pms: tourist tax count with partially registered guests

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2706,20 +2706,29 @@ class PmsReservation(models.Model):
         )
 
     def _get_applicable_guest_count(self, product):
-        count = len(
-            self._get_guests_by_age(
-                product.tourist_tax_min_age,
-                product.tourist_tax_max_age,
-            )
+        """Count the guests the tax applies to.
+
+        Guests with a known birthdate are classified by age; guests not yet
+        registered (or registered without birthdate) are counted from the
+        declared occupancy, so a partial check-in never lowers the tax below
+        what the reservation declares.
+        """
+        min_age = product.tourist_tax_min_age
+        max_age = product.tourist_tax_max_age
+        known_guests = self.checkin_partner_ids.filtered("birthdate_date")
+        matching_known = len(self._get_guests_by_age(min_age, max_age) & known_guests)
+        unknown_count = max(0, self.adults + self.children - len(known_guests))
+        if not min_age:
+            # Without a minimum age, guests of unknown age are counted,
+            # consistent with _get_guests_by_age
+            return matching_known + unknown_count
+        # With a minimum age, assume unregistered adults meet it and
+        # declared children not yet identified as minors stay below it
+        known_minors = len(
+            known_guests.filtered(lambda g: self._guest_age(g.birthdate_date) < min_age)
         )
-        # If not hosts found, consider all guests (if not min_age or max_age is set)
-        # or only adults min_age
-        if count == 0:
-            if not product.tourist_tax_min_age:
-                count = self.adults + self.children
-            else:
-                count = self.adults
-        return count
+        unknown_children = max(0, self.children - known_minors)
+        return matching_known + max(0, unknown_count - unknown_children)
 
     def _get_product_price(self, product, quantity, night_date):
         product = product.with_context(
@@ -2807,20 +2816,18 @@ class PmsReservation(models.Model):
 
         return cmds
 
-    def _get_guests_by_age(self, min_age=None, max_age=None):
+    @api.model
+    def _guest_age(self, birthdate):
         today = fields.Date.today()
-        guests = self.checkin_partner_ids
+        return (today - birthdate).days // 365 if birthdate else 0
 
-        def age(birthdate):
-            return (today - birthdate).days // 365 if birthdate else 0
-
-        filtered = guests.filtered(
+    def _get_guests_by_age(self, min_age=None, max_age=None):
+        return self.checkin_partner_ids.filtered(
             lambda g: (
-                (not min_age or age(g.birthdate_date) >= min_age)
-                and (not max_age or age(g.birthdate_date) <= max_age)
+                (not min_age or self._guest_age(g.birthdate_date) >= min_age)
+                and (not max_age or self._guest_age(g.birthdate_date) <= max_age)
             )
         )
-        return filtered
 
     def _is_mmdd_in_range(self, check_date, start_mmdd, end_mmdd):
         """Check if a date falls between two MM-DD values,

--- a/pms/tests/test_pms_tourist_tax.py
+++ b/pms/tests/test_pms_tourist_tax.py
@@ -36,10 +36,34 @@ class TestTouristTaxComputation(TestPms):
             }
         )
 
+        cls.room_type_quad = cls.env["pms.room.type"].create(
+            {
+                "pms_property_ids": [cls.pms_property1.id],
+                "name": "Quad Test",
+                "default_code": "QUA_Test",
+                "class_id": cls.room_type_class1.id,
+            }
+        )
+
+        cls.room2 = cls.env["pms.room"].create(
+            {
+                "pms_property_id": cls.pms_property1.id,
+                "name": "Quad 201",
+                "room_type_id": cls.room_type_quad.id,
+                "capacity": 4,
+            }
+        )
+
         cls.partner_adult = cls.env["res.partner"].create(
             {
                 "firstname": "Adult",
                 "birthdate_date": "1990-01-01",
+            }
+        )
+
+        cls.partner_adult_no_birthdate = cls.env["res.partner"].create(
+            {
+                "firstname": "AdultNoBirthdate",
             }
         )
 
@@ -298,3 +322,161 @@ class TestTouristTaxComputation(TestPms):
         for line in high.service_line_ids:
             self.assertEqual(line.day_qty, 1)
             self.assertEqual(line.price_unit, 2.0)
+
+    @freeze_time("2025-07-01")
+    def test_tourist_tax_partial_checkin_counts_declared_guests(self):
+        """
+        Test that with 3 declared adults and only one of them registered,
+        the tax is still computed for the 3 declared guests.
+        """
+        self.env["product.product"].create(
+            {
+                "name": "Tourist Tax",
+                "list_price": 2.0,
+                "is_tourist_tax": True,
+                "per_person": True,
+                "tourist_tax_date_start": "06-01",
+                "tourist_tax_date_end": "09-30",
+                "tourist_tax_apply_from_night": 1,
+                "tourist_tax_apply_to_night": 3,
+                "tourist_tax_min_age": 14,
+            }
+        )
+
+        checkin = fields.Date.today()
+        checkout = checkin + datetime.timedelta(days=3)
+
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_quad.id,
+                "partner_id": self.partner_adult.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "adults": 3,
+                "checkin_partner_ids": [
+                    (0, 0, {"partner_id": self.partner_adult.id}),
+                ],
+                "pms_property_id": self.pms_property1.id,
+                "pricelist_id": self.pricelist1.id,
+            }
+        )
+
+        tax_services = reservation.service_ids.filtered(
+            lambda s: s.product_id.product_tmpl_id.is_tourist_tax
+        )
+        self.assertEqual(
+            len(tax_services), 1, "Should generate one tourist tax service"
+        )
+        for line in tax_services.service_line_ids:
+            self.assertEqual(
+                line.day_qty,
+                3,
+                "All declared adults should be taxed, registered or not",
+            )
+
+    @freeze_time("2025-07-01")
+    def test_tourist_tax_partial_checkin_excludes_declared_children(self):
+        """
+        Test that with 2 adults and 2 children declared and only one adult
+        registered, the tax is computed for the 2 declared adults only.
+        """
+        self.env["product.product"].create(
+            {
+                "name": "Tourist Tax",
+                "list_price": 2.0,
+                "is_tourist_tax": True,
+                "per_person": True,
+                "tourist_tax_date_start": "06-01",
+                "tourist_tax_date_end": "09-30",
+                "tourist_tax_apply_from_night": 1,
+                "tourist_tax_apply_to_night": 3,
+                "tourist_tax_min_age": 14,
+            }
+        )
+
+        checkin = fields.Date.today()
+        checkout = checkin + datetime.timedelta(days=3)
+
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_quad.id,
+                "partner_id": self.partner_adult.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "adults": 2,
+                "children": 2,
+                "checkin_partner_ids": [
+                    (0, 0, {"partner_id": self.partner_adult.id}),
+                ],
+                "pms_property_id": self.pms_property1.id,
+                "pricelist_id": self.pricelist1.id,
+            }
+        )
+
+        tax_services = reservation.service_ids.filtered(
+            lambda s: s.product_id.product_tmpl_id.is_tourist_tax
+        )
+        self.assertEqual(
+            len(tax_services), 1, "Should generate one tourist tax service"
+        )
+        for line in tax_services.service_line_ids:
+            self.assertEqual(
+                line.day_qty,
+                2,
+                "Only the declared adults should be taxed",
+            )
+
+    @freeze_time("2025-07-01")
+    def test_tourist_tax_registered_guest_without_birthdate_counts(self):
+        """
+        Test that a registered guest without birthdate is counted as a
+        declared adult instead of being excluded from the tax.
+        """
+        self.env["product.product"].create(
+            {
+                "name": "Tourist Tax",
+                "list_price": 2.0,
+                "is_tourist_tax": True,
+                "per_person": True,
+                "tourist_tax_date_start": "06-01",
+                "tourist_tax_date_end": "09-30",
+                "tourist_tax_apply_from_night": 1,
+                "tourist_tax_apply_to_night": 3,
+                "tourist_tax_min_age": 14,
+            }
+        )
+
+        checkin = fields.Date.today()
+        checkout = checkin + datetime.timedelta(days=3)
+
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": checkin,
+                "checkout": checkout,
+                "room_type_id": self.room_type_double.id,
+                "partner_id": self.partner_adult.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "adults": 2,
+                "checkin_partner_ids": [
+                    (0, 0, {"partner_id": self.partner_adult.id}),
+                    (0, 0, {"partner_id": self.partner_adult_no_birthdate.id}),
+                ],
+                "pms_property_id": self.pms_property1.id,
+                "pricelist_id": self.pricelist1.id,
+            }
+        )
+
+        tax_services = reservation.service_ids.filtered(
+            lambda s: s.product_id.product_tmpl_id.is_tourist_tax
+        )
+        self.assertEqual(
+            len(tax_services), 1, "Should generate one tourist tax service"
+        )
+        for line in tax_services.service_line_ids:
+            self.assertEqual(
+                line.day_qty,
+                2,
+                "Guests without birthdate should be taxed as declared adults",
+            )


### PR DESCRIPTION
The per-person tourist tax quantity was computed only from the checkin partners whose birthdate passes the product age filter. As soon as one guest registered with a birthdate, the quantity dropped to those registered guests, ignoring the rest of the declared occupancy. Registered guests without a birthdate were excluded as well.

**Example** (tax with `tourist_tax_min_age = 16`): a reservation for 3 adults is created and the tax is charged for 3 guests (fallback to declared adults). One guest completes the check-in with an adult birthdate and the tax silently drops to 1 guest per night.

**Fix**: guests with a known birthdate are classified by age; the rest of the declared occupancy fills in the count (adults are assumed to meet the minimum age, declared children to stay below it). A partial check-in can no longer lower the tax below what the reservation declares, while real birthdates still grant age exemptions.

Includes regression tests for the partial check-in scenarios (all-adult, adults with declared children, and registered guest without birthdate).