### PR TITLE
[16.0][FIX] pms: propagate scoped real_avail recompute to plan rules

### DIFF
--- a/pms/models/pms_availability.py
+++ b/pms/models/pms_availability.py
@@ -165,6 +165,13 @@ class PmsAvailability(models.Model):
         )
         if avails:
             self.env.add_to_compute(self._fields["real_avail"], avails)
+            # ``add_to_compute`` marks ``real_avail`` itself but, unlike
+            # ``modified()``, does not expand the dependency closure:
+            # stored fields depending on it — the related
+            # ``pms.availability.plan.rule.real_avail`` and, through it,
+            # ``plan_avail`` (the value channel exports read) — would
+            # keep their stale values. Mark them explicitly.
+            avails.modified(["real_avail"])
 
     @api.depends("reservation_line_ids", "reservation_line_ids.room_id")
     def _compute_parent_avail_id(self):

--- a/pms/tests/test_pms_availability_plan_rules.py
+++ b/pms/tests/test_pms_availability_plan_rules.py
@@ -628,3 +628,55 @@ class TestPmsRoomTypeAvailabilityRules(TestPms):
                     "partner_id": self.partner1.id,
                 }
             )
+
+    def test_room_deactivation_updates_plan_avail(self):
+        """
+        Check that deactivating a room propagates to the plan rules.
+        --------------------------------------------------------------
+        Room type with 2 rooms, one reservation and an availability rule
+        for the same date: plan_avail is 1. Deactivating the remaining
+        free room must leave the room type with a single (occupied)
+        active room, so both the rule's real_avail and plan_avail must
+        be recomputed to 0. plan_avail is the value channel exports
+        read, so a stale value here oversells on the OTAs.
+        """
+        # ARRANGE
+        checkin = fields.date.today() + datetime.timedelta(days=1)
+        checkout = checkin + datetime.timedelta(days=1)
+        rule = self.env["pms.availability.plan.rule"].create(
+            {
+                "availability_plan_id": self.test_room_type_availability1.id,
+                "room_type_id": self.test_room_type_double.id,
+                "date": checkin,
+                "pms_property_id": self.pms_property3.id,
+            }
+        )
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.pms_property3.id,
+                "checkin": checkin,
+                "checkout": checkout,
+                "partner_id": self.partner1.id,
+                "room_type_id": self.test_room_type_double.id,
+                "sale_channel_origin_id": self.sale_channel_direct1.id,
+            }
+        )
+        self.assertEqual(
+            rule.plan_avail,
+            1,
+            "One of the two rooms is occupied, plan_avail should be 1",
+        )
+        free_room = (
+            self.test_room1_double + self.test_room2_double
+        ) - reservation.reservation_line_ids.room_id
+
+        # ACT
+        free_room.active = False
+
+        # ASSERT
+        self.assertEqual(
+            rule.plan_avail,
+            0,
+            "The only active room of the room type is occupied, the"
+            "rule's plan_avail should have been recomputed to 0",
+        )


### PR DESCRIPTION
The scoped recompute introduced for `pms.room` changes (create / write of `active`, `room_type_id`, `pms_property_id`, `parent_id` / unlink) marks `pms.availability.real_avail` with `env.add_to_compute()`. Unlike `modified()`, `add_to_compute()` does not expand the dependency closure, so stored fields depending on `real_avail` are never invalidated:

- `pms.availability.plan.rule.real_avail` (related, stored) keeps its stale copy, and
- `plan_avail`, computed from it, keeps the stale availability.

Since `plan_avail` is the value channel/OTA exports read, any availability plan rule existing on the affected dates keeps selling the pre-change availability after a room is deactivated or re-segmented, even though `pms.availability.real_avail` itself is correctly recomputed. On a room deactivation this oversells the channel (overbooking); on the opposite change it undersells.

The fix marks the availability records' `real_avail` as `modified()` right after scheduling the recompute, so the dependent stored fields are recomputed within the same flush.

Includes a regression test: with a room type of 2 rooms, 1 reservation and an availability rule on the same date, deactivating the free room must recompute the rule's `plan_avail` to 0 (it stayed at 1 before this fix).