### PR TITLE
[16.0][FIX] pms: validate HH:MM hours with a single format check

### DIFF
--- a/pms/__manifest__.py
+++ b/pms/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "PMS (Property Management System)",
     "summary": "A property management system",
-    "version": "16.0.4.15.0",
+    "version": "16.0.4.16.0",
     "development_status": "Beta",
     "category": "Generic Modules/Property Management System",
     "website": "https://github.com/OCA/pms",

--- a/pms/migrations/16.0.4.16.0/pre-migration.py
+++ b/pms/migrations/16.0.4.16.0/pre-migration.py
@@ -1,0 +1,97 @@
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+# The hour fields stored as Char only accept a zero-padded 24h "HH:MM" string
+# now. Values stored while the check accepted anything strptime("%H:%M")
+# parsed are normalized here, or their records cannot be written again.
+_NORMALIZE_PROPERTY_HOURS = """
+    UPDATE pms_property
+    SET default_arrival_hour = CASE
+            WHEN default_arrival_hour = '24:00' THEN '23:59'
+            WHEN default_arrival_hour ~ '^[0-9]{1,2}:[0-9]{1,2}$'
+                THEN lpad(split_part(default_arrival_hour, ':', 1), 2, '0')
+                     || ':'
+                     || lpad(split_part(default_arrival_hour, ':', 2), 2, '0')
+            ELSE default_arrival_hour
+        END,
+        default_departure_hour = CASE
+            WHEN default_departure_hour = '24:00' THEN '23:59'
+            WHEN default_departure_hour ~ '^[0-9]{1,2}:[0-9]{1,2}$'
+                THEN lpad(split_part(default_departure_hour, ':', 1), 2, '0')
+                     || ':'
+                     || lpad(split_part(default_departure_hour, ':', 2), 2, '0')
+            ELSE default_departure_hour
+        END
+    WHERE default_arrival_hour !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+       OR default_departure_hour !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+"""
+
+_NORMALIZE_RESERVATION_HOURS = """
+    UPDATE pms_reservation
+    SET arrival_hour = CASE
+            WHEN arrival_hour = '24:00' THEN '23:59'
+            WHEN arrival_hour ~ '^[0-9]{1,2}:[0-9]{1,2}$'
+                THEN lpad(split_part(arrival_hour, ':', 1), 2, '0')
+                     || ':'
+                     || lpad(split_part(arrival_hour, ':', 2), 2, '0')
+            ELSE arrival_hour
+        END,
+        departure_hour = CASE
+            WHEN departure_hour = '24:00' THEN '23:59'
+            WHEN departure_hour ~ '^[0-9]{1,2}:[0-9]{1,2}$'
+                THEN lpad(split_part(departure_hour, ':', 1), 2, '0')
+                     || ':'
+                     || lpad(split_part(departure_hour, ':', 2), 2, '0')
+            ELSE departure_hour
+        END
+    WHERE arrival_hour !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+       OR departure_hour !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+"""
+
+# The property hours are required now.
+_FILL_EMPTY_PROPERTY_HOURS = """
+    UPDATE pms_property
+    SET default_arrival_hour = COALESCE(NULLIF(default_arrival_hour, ''), '14:00'),
+        default_departure_hour = COALESCE(NULLIF(default_departure_hour, ''), '12:00')
+    WHERE default_arrival_hour IS NULL OR default_arrival_hour = ''
+       OR default_departure_hour IS NULL OR default_departure_hour = ''
+"""
+
+_SELECT_NOT_NORMALIZED = """
+    SELECT 'pms_property.default_arrival_hour', id, default_arrival_hour
+    FROM pms_property
+    WHERE default_arrival_hour !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+    UNION ALL
+    SELECT 'pms_property.default_departure_hour', id, default_departure_hour
+    FROM pms_property
+    WHERE default_departure_hour !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+    UNION ALL
+    SELECT 'pms_reservation.arrival_hour', id, arrival_hour
+    FROM pms_reservation
+    WHERE arrival_hour IS NOT NULL
+      AND arrival_hour !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+    UNION ALL
+    SELECT 'pms_reservation.departure_hour', id, departure_hour
+    FROM pms_reservation
+    WHERE departure_hour IS NOT NULL
+      AND departure_hour !~ '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+"""
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(env.cr, _NORMALIZE_PROPERTY_HOURS)
+    openupgrade.logged_query(env.cr, _NORMALIZE_RESERVATION_HOURS)
+    openupgrade.logged_query(env.cr, _FILL_EMPTY_PROPERTY_HOURS)
+    env.cr.execute(_SELECT_NOT_NORMALIZED)
+    not_normalized = env.cr.fetchall()
+    if not_normalized:
+        _logger.warning(
+            "%s hour value(s) are not an hour and were left untouched, "
+            "they need a manual review: %s",
+            len(not_normalized),
+            not_normalized,
+        )

--- a/pms/models/pms_property.py
+++ b/pms/models/pms_property.py
@@ -4,7 +4,7 @@
 
 import base64
 import datetime
-import time
+import re
 
 import pytz
 
@@ -14,6 +14,8 @@ from odoo.osv import expression
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT
 
 from odoo.addons.base.models.res_partner import _tz_get
+
+HOUR_STR_PATTERN = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
 
 
 def get_default_logo():
@@ -79,10 +81,10 @@ class PmsProperty(models.Model):
         default=lambda self: self.env.ref("product.list0").id,
     )
     default_arrival_hour = fields.Char(
-        string="Arrival Hour", help="HH:mm Format", default="14:00"
+        string="Arrival Hour", help="HH:mm Format", default="14:00", required=True
     )
     default_departure_hour = fields.Char(
-        string="Departure Hour", help="HH:mm Format", default="12:00"
+        string="Departure Hour", help="HH:mm Format", default="12:00", required=True
     )
     folio_sequence_id = fields.Many2one(
         string="Folio Sequence",
@@ -577,24 +579,46 @@ class PmsProperty(models.Model):
     @api.constrains("default_arrival_hour")
     def _check_arrival_hour(self):
         for record in self:
-            try:
-                time.strptime(record.default_arrival_hour, "%H:%M")
-            except ValueError as e:
+            if not self.is_valid_hour_str(record.default_arrival_hour):
                 raise ValidationError(
                     _("Format Arrival Hour (HH:MM) Error: %s")
                     % record.default_arrival_hour
-                ) from e
+                )
 
     @api.constrains("default_departure_hour")
     def _check_departure_hour(self):
         for record in self:
-            try:
-                time.strptime(record.default_departure_hour, "%H:%M")
-            except ValueError as e:
+            if not self.is_valid_hour_str(record.default_departure_hour):
                 raise ValidationError(
                     _("Format Departure Hour (HH:MM) Error: %s")
                     % record.default_departure_hour
-                ) from e
+                )
+
+    @api.model
+    def is_valid_hour_str(self, hour_str):
+        """Return whether hour_str is a zero-padded 24h "HH:MM" string.
+
+        Stricter on purpose than time.strptime(hour_str, "%H:%M"), which
+        also accepts hours without zero padding ("8:00") that the hour
+        consumers, parsing by position, cannot read back.
+        """
+        return bool(hour_str) and bool(HOUR_STR_PATTERN.match(hour_str))
+
+    @api.model
+    def hour_str_to_time(self, hour_str):
+        """Return the "HH:MM" hour_str as a datetime.time."""
+        if not self.is_valid_hour_str(hour_str):
+            raise ValidationError(_("Format Hour (HH:MM) Error: %s") % hour_str)
+        hour, minute = hour_str.split(":")
+        return datetime.time(int(hour), int(minute))
+
+    def datetime_from_hour_str(self, local_date, hour_str):
+        """Return local_date at hour_str, from property to user timezone."""
+        self.ensure_one()
+        local_dt = datetime.datetime.combine(
+            local_date, self.hour_str_to_time(hour_str)
+        )
+        return self.date_property_timezone(local_dt)
 
     def date_property_timezone(self, dt):
         self.ensure_one()

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -3,7 +3,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 import datetime
 import logging
-import time
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError, ValidationError
@@ -833,27 +832,25 @@ class PmsReservation(models.Model):
     @api.depends("checkin", "arrival_hour")
     def _compute_checkin_datetime(self):
         for reservation in self:
-            checkin_hour = int(reservation.arrival_hour[0:2])
-            checkin_minut = int(reservation.arrival_hour[3:5])
-            checkin_time = datetime.time(checkin_hour, checkin_minut)
-            checkin_datetime = datetime.datetime.combine(
-                reservation.checkin, checkin_time
-            )
+            if not reservation.checkin or not reservation.arrival_hour:
+                reservation.checkin_datetime = False
+                continue
             reservation.checkin_datetime = (
-                reservation.pms_property_id.date_property_timezone(checkin_datetime)
+                reservation.pms_property_id.datetime_from_hour_str(
+                    reservation.checkin, reservation.arrival_hour
+                )
             )
 
     @api.depends("checkout", "departure_hour")
     def _compute_checkout_datetime(self):
         for reservation in self:
-            checkout_hour = int(reservation.departure_hour[0:2])
-            checkout_minut = int(reservation.departure_hour[3:5])
-            checkout_time = datetime.time(checkout_hour, checkout_minut)
-            checkout_datetime = datetime.datetime.combine(
-                reservation.checkout, checkout_time
-            )
+            if not reservation.checkout or not reservation.departure_hour:
+                reservation.checkout_datetime = False
+                continue
             reservation.checkout_datetime = (
-                reservation.pms_property_id.date_property_timezone(checkout_datetime)
+                reservation.pms_property_id.datetime_from_hour_str(
+                    reservation.checkout, reservation.departure_hour
+                )
             )
 
     @api.depends(
@@ -1856,28 +1853,28 @@ class PmsReservation(models.Model):
 
     @api.constrains("arrival_hour")
     def _check_arrival_hour(self):
+        pms_property = self.env["pms.property"]
         for record in self:
-            if record.arrival_hour:
-                try:
-                    time.strptime(record.arrival_hour, "%H:%M")
-                except ValueError as err:
-                    raise ValidationError(
-                        _("Format Arrival Hour (HH:MM) Error: %s", record.arrival_hour)
-                    ) from err
+            if record.arrival_hour and not pms_property.is_valid_hour_str(
+                record.arrival_hour
+            ):
+                raise ValidationError(
+                    _("Format Arrival Hour (HH:MM) Error: %s", record.arrival_hour)
+                )
 
     @api.constrains("departure_hour")
     def _check_departure_hour(self):
+        pms_property = self.env["pms.property"]
         for record in self:
-            if record.departure_hour:
-                try:
-                    time.strptime(record.departure_hour, "%H:%M")
-                except ValueError as err:
-                    raise ValidationError(
-                        _(
-                            "Format Departure Hour (HH:MM) Error: %s",
-                            record.departure_hour,
-                        )
-                    ) from err
+            if record.departure_hour and not pms_property.is_valid_hour_str(
+                record.departure_hour
+            ):
+                raise ValidationError(
+                    _(
+                        "Format Departure Hour (HH:MM) Error: %s",
+                        record.departure_hour,
+                    )
+                )
 
     @api.constrains("agency_id")
     def _no_agency_as_agency(self):

--- a/pms/tests/__init__.py
+++ b/pms/tests/__init__.py
@@ -45,3 +45,4 @@ from . import test_pms_service
 from . import test_pms_tourist_tax
 from . import test_pms_payment
 from . import test_res_partner
+from . import test_pms_property

--- a/pms/tests/common.py
+++ b/pms/tests/common.py
@@ -1,5 +1,16 @@
 from odoo.tests import common
 
+INVALID_HOURS = [
+    "8:00",
+    "8:0",
+    "1400",
+    "14:00:00",
+    "24:00",
+    "14:99",
+    "aa:bb",
+    "14:",
+]
+
 
 class TestPms(common.TransactionCase):
     @classmethod

--- a/pms/tests/test_pms_property.py
+++ b/pms/tests/test_pms_property.py
@@ -1,0 +1,30 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+
+from .common import INVALID_HOURS, TestPms
+
+
+@tagged("post_install", "-at_install")
+class TestPmsPropertyHours(TestPms):
+    def test_default_hours_invalid_format(self):
+        """
+        Check that the property hours are a zero-padded 24h "HH:MM" string
+        -------------
+        Create a property for each hour that is not one, on both hour
+        fields, this should throw an error. "8:00" is the value that
+        broke production: the check accepted it and the consumers
+        parsing the hour by position could not read it back.
+        """
+        for hour in INVALID_HOURS:
+            for field in ("default_arrival_hour", "default_departure_hour"):
+                with self.subTest(hour=hour, field=field), self.assertRaises(
+                    ValidationError
+                ):
+                    self.env["pms.property"].create(
+                        {
+                            "name": "Property hour format",
+                            "company_id": self.company1.id,
+                            "default_pricelist_id": self.pricelist1.id,
+                            field: hour,
+                        }
+                    )

--- a/pms/tests/test_pms_reservation.py
+++ b/pms/tests/test_pms_reservation.py
@@ -8,7 +8,7 @@ from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
-from .common import TestPms
+from .common import INVALID_HOURS, TestPms
 
 
 @tagged("post_install", "-at_install")
@@ -1265,48 +1265,99 @@ class TestPmsReservations(TestPms, AccountTestInvoicingCommon):
         """
         Check that the format of the arrival_hour field is correct(HH:mm)
         -------------
-        Create a reservation with the wrong arrival hour date
-        format (HH:mm:ss), this should throw an error.
+        Create a reservation for each hour that is not a zero-padded 24h
+        "HH:mm" string, this should throw an error.
         """
         self.host1 = self.env["res.partner"].create(
             {
                 "firstname": "Host1",
             }
         )
-        with self.assertRaises(ValidationError):
-            self.env["pms.reservation"].create(
-                {
-                    "checkin": fields.date.today(),
-                    "checkout": fields.date.today() + datetime.timedelta(days=3),
-                    "pms_property_id": self.pms_property1.id,
-                    "partner_id": self.host1.id,
-                    "arrival_hour": "14:00:00",
-                }
-            )
+        for hour in INVALID_HOURS:
+            with self.subTest(hour=hour), self.assertRaises(ValidationError):
+                self.env["pms.reservation"].create(
+                    {
+                        "checkin": fields.date.today(),
+                        "checkout": fields.date.today() + datetime.timedelta(days=3),
+                        "pms_property_id": self.pms_property1.id,
+                        "partner_id": self.host1.id,
+                        "arrival_hour": hour,
+                    }
+                )
 
     @freeze_time("2012-01-14")
     def test_check_format_departure_hour(self):
         """
         Check that the format of the departure_hour field is correct(HH:mm)
         -------------
-        Create a reservation with the wrong departure hour date
-        format (HH:mm:ss), this should throw an error.
+        Create a reservation for each hour that is not a zero-padded 24h
+        "HH:mm" string, this should throw an error.
         """
         self.host1 = self.env["res.partner"].create(
             {
                 "firstname": "Host1",
             }
         )
-        with self.assertRaises(ValidationError):
-            self.env["pms.reservation"].create(
-                {
-                    "checkin": fields.date.today(),
-                    "checkout": fields.date.today() + datetime.timedelta(days=3),
-                    "pms_property_id": self.pms_property1.id,
-                    "partner_id": self.host1.id,
-                    "departure_hour": "14:00:00",
-                }
-            )
+        for hour in INVALID_HOURS:
+            with self.subTest(hour=hour), self.assertRaises(ValidationError):
+                self.env["pms.reservation"].create(
+                    {
+                        "checkin": fields.date.today(),
+                        "checkout": fields.date.today() + datetime.timedelta(days=3),
+                        "pms_property_id": self.pms_property1.id,
+                        "partner_id": self.host1.id,
+                        "departure_hour": hour,
+                    }
+                )
+
+    @freeze_time("2012-01-14")
+    def test_checkin_checkout_datetime_hours(self):
+        """
+        Check that the exact arrival and departure keep the property hours
+        -------------
+        Create a reservation on a property arriving at 08:00 and leaving
+        at 00:00, and check that both datetimes are on those hours.
+        """
+        self.env.user.tz = "UTC"
+        self.pms_property1.tz = "UTC"
+        self.pms_property1.default_arrival_hour = "08:00"
+        self.pms_property1.default_departure_hour = "00:00"
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": fields.date.today(),
+                "checkout": fields.date.today() + datetime.timedelta(days=3),
+                "pms_property_id": self.pms_property1.id,
+                "partner_id": self.partner1.id,
+                "room_type_id": self.room_type_double.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+        self.assertEqual(
+            reservation.checkin_datetime,
+            datetime.datetime.combine(reservation.checkin, datetime.time(8, 0)),
+        )
+        self.assertEqual(
+            reservation.checkout_datetime,
+            datetime.datetime.combine(reservation.checkout, datetime.time(0, 0)),
+        )
+
+    def test_checkin_checkout_datetime_without_hours(self):
+        """
+        Check that a reservation without hours has no exact arrival
+        -------------
+        On a new reservation the checkin and checkout dates are not set
+        yet, so both datetimes are computed from missing values.
+        """
+        reservation = self.env["pms.reservation"].new(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "partner_id": self.partner1.id,
+                "arrival_hour": False,
+                "departure_hour": False,
+            }
+        )
+        self.assertFalse(reservation.checkin_datetime)
+        self.assertFalse(reservation.checkout_datetime)
 
     @freeze_time("2012-01-14")
     def test_check_property_integrity_room(self):


### PR DESCRIPTION
### Bug

The hour fields stored as `Char` (`pms.property.default_arrival_hour` and
`default_departure_hour`, `pms.reservation.arrival_hour` and `departure_hour`)
were checked with `time.strptime(hour, "%H:%M")`, which does not require zero
padding, so `"8:00"` passed the check and was stored.

The consumers read the hour by position, so `int(arrival_hour[0:2])` is
`int("8:")`: a value the check accepted raised `ValueError` in
`_compute_checkin_datetime`, and everything reading `checkin_datetime` failed
with it, mail templates included.

### Solution

One regex, `^([01]\d|2[0-3]):[0-5]\d$`, replaces the four `strptime` calls, and
`pms.property` owns the only parser (`is_valid_hour_str`, `hour_str_to_time`
and `datetime_from_hour_str`), used both by the checks and by the checkin and
checkout datetime computes, which no longer slice the string.

Those computes return no value when the date or the hour is missing, instead of
raising `TypeError`, and the property hours become required: they always had a
default, and the empty branch only made the check raise.

### Migration

The stricter check would leave the records holding an unpadded hour unwritable,
so `16.0.4.13.0/pre-migration.py` normalizes what is already stored:

- hours recoverable by zero padding are padded, `"9:00"` to `"09:00"`
- `"24:00"` becomes `"23:59"`, keeping its end of day meaning
- empty property hours take the field default, now that they are required
- anything else is left untouched and logged with its table, column and id:
  guessing a value would be worse than reporting it
