### PR TITLE
[16.0][FIX] pms_l10n_es: create SES communications for room-level SES accounts

### DIFF
--- a/pms_l10n_es/models/pms_checkin_partner.py
+++ b/pms_l10n_es/models/pms_checkin_partner.py
@@ -147,7 +147,7 @@ class PmsCheckinPartner(models.Model):
         for record in self:
             if (
                 "state" in vals
-                and record.reservation_id.pms_property_id.institution == "ses"
+                and record.reservation_id.is_ses
                 and record.state == "onboard"
             ):
                 previous_incomplete_traveller_communication = self.env[

--- a/pms_l10n_es/models/pms_reservation.py
+++ b/pms_l10n_es/models/pms_reservation.py
@@ -61,7 +61,7 @@ class PmsReservation(models.Model):
 
     def _compute_ses_status_reservation(self):
         for record in self:
-            if record.pms_property_id.institution != "ses":
+            if not record.is_ses:
                 record.ses_status_reservation = "not_applicable"
                 continue
             communication = record.ses_communication_ids.filtered(
@@ -76,7 +76,7 @@ class PmsReservation(models.Model):
 
     def _compute_ses_status_traveller_report(self):
         for record in self:
-            if record.pms_property_id.institution != "ses":
+            if not record.is_ses:
                 record.ses_status_traveller_report = "not_applicable"
                 continue
             communication = record.ses_communication_ids.filtered(
@@ -108,10 +108,7 @@ class PmsReservation(models.Model):
     def create(self, vals_list):
         reservations = super().create(vals_list)
         for reservation in reservations:
-            if (
-                reservation.pms_property_id.institution == "ses"
-                and reservation.reservation_type != "out"
-            ):
+            if reservation.is_ses and reservation.reservation_type != "out":
                 self.create_communication(reservation.id, CREATE_OPERATION_CODE, "RH")
         return reservations
 

--- a/pms_l10n_es/tests/test_pms_ses_communication.py
+++ b/pms_l10n_es/tests/test_pms_ses_communication.py
@@ -58,6 +58,43 @@ class TestPmsSesCommunication(TestPms):
             "Creating a reservation should create a notification with operation A",
         )
 
+    def test_create_notification_when_room_has_independent_ses_account(self):
+        # ARRANGE
+        self.pms_property1.institution = False
+        self.room_double_1.institution_independent_account = True
+        self.room_double_1.institution = "ses"
+        # ACT
+        reservation = self.env["pms.reservation"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "room_type_id": self.room_type.id,
+                "preferred_room_id": self.room_double_1.id,
+                "checkin": "2021-01-01",
+                "checkout": "2021-01-02",
+                "adults": 2,
+                "children": 0,
+                "sale_channel_origin_id": self.sale_channel_direct1.id,
+                "partner_name": "Test reservation",
+            }
+        )
+        # ASSERT
+        self.assertTrue(
+            reservation.is_ses,
+            "A reservation in a room with an independent SES account "
+            "should be flagged as SES",
+        )
+        last_notification = self.env["pms.ses.communication"].search(
+            [
+                ("reservation_id", "=", reservation.id),
+            ]
+        )
+        self.assertEqual(
+            last_notification.operation,
+            "A",
+            "Creating a reservation in a room with an independent SES "
+            "account should create a notification with operation A",
+        )
+
     def test_not_create_notification_when_cancel_reservation_and_not_sent(self):
         # ARRANGE
         reservation = self.env["pms.reservation"].create(


### PR DESCRIPTION
Properties whose SES accounts are configured **per room** (`institution_independent_account` on `pms.room`, each room acting as its own establishment with its own code and credentials) have an empty `institution` field on the property. The hooks that create SES communications and the SES status computes gated on `pms_property_id.institution == 'ses'`, so for these setups:

- `pms.reservation.create()` never created the RH (reservation notification) communication,
- `pms.checkin.partner.write()` never created the PV (traveller report) communication,
- both SES status computes returned `not_applicable`, which hid the problem instead of surfacing pending/error states — the UI looked as if SES simply did not apply.

Meanwhile `_compute_is_ses` (and the reservation `write()` hook, and the XML generation / authentication code) already handle the room-level account case correctly, so the model contradicted itself: `is_ses` was `True` while no communication was ever created.

**Fix**: gate the two creation hooks and the two status computes on `reservation.is_ses`, consistently with the reservation `write()` hook. Rooms without any SES account in a mixed-use property (e.g. resources managed in the planning that are not accommodations) stay cleanly excluded because their `is_ses` is `False`.

Includes a regression test: a reservation in a room with an independent SES account on a property without institution must create the RH communication.