### PR TITLE
[16.0][FIX] pms_partner_identification: look up partner document by its unique key

### DIFF
--- a/pms_partner_identification/models/pms_checkin_partner.py
+++ b/pms_partner_identification/models/pms_checkin_partner.py
@@ -211,7 +211,6 @@ class PmsCheckinPartner(models.Model):
                     [
                         ("partner_id", "=", record.partner_id.id),
                         ("category_id", "=", record.document_type.id),
-                        ("country_id", "=", record.document_country_id.id),
                     ],
                     limit=1,
                 )


### PR DESCRIPTION
The unique index on `res.partner.id_number` is `(partner_id, category_id)`.

`_create_or_update_partner_document` searches the existing document also by `country_id`, so any legacy row whose country is not set (or differs from the one captured at check-in) is not found. The method then falls into `create()` and crashes against the unique constraint when the check-in is saved.

This searches by the uniqueness key only: the subsequent `write()` updates the existing document and backfills its country from the check-in data, so legacy documents self-correct on the guest's next check-in without any data migration.