### PR TITLE
[16.0][FIX] pms: do not overwrite reservation guest name with folio partner name

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -1521,6 +1521,9 @@ class PmsFolio(models.Model):
         if "sale_channel_origin_id" in vals:
             reservations_to_update = self.get_reservations_to_update_channel(vals)
             services_to_update = self.get_services_to_update_channel(vals)
+        folio_old_partner_names = {}
+        if vals.get("partner_name") or vals.get("partner_id"):
+            folio_old_partner_names = {folio.id: folio.partner_name for folio in self}
 
         res = super().write(vals)
         if vals.get("partner_id"):
@@ -1533,6 +1536,19 @@ class PmsFolio(models.Model):
 
         if services_to_update:
             services_to_update.sale_channel_origin_id = vals["sale_channel_origin_id"]
+
+        if folio_old_partner_names:
+            # Propagate the folio holder rename only to reservations that
+            # inherited the previous folio name (or have no name), keeping
+            # the guest names that were set explicitly on each reservation.
+            for folio in self:
+                old_name = folio_old_partner_names.get(folio.id)
+                new_name = folio.partner_name
+                if not new_name or new_name == old_name:
+                    continue
+                folio.reservation_ids.filtered(
+                    lambda r, old=old_name: not r.partner_name or r.partner_name == old
+                ).partner_name = new_name
 
         return res
 

--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -1438,23 +1438,27 @@ class PmsReservation(models.Model):
             else:
                 record.shared_folio = False
 
+    # NOTE: no dependency on folio_id.partner_name on purpose: a recompute
+    # triggered by a folio rename cannot see the reservation's own stored
+    # partner_name (the cache is invalidated), so it would overwrite the
+    # guest names. Folio renames are propagated from pms.folio.write()
+    # instead, only to the reservations that inherited the folio name.
     @api.depends(
         "partner_id",
         "partner_id.name",
         "agency_id",
         "reservation_type",
         "out_service_description",
-        "folio_id.partner_name",
     )
     def _compute_partner_name(self):
         for record in self:
             if record.partner_id and record.partner_id != record.agency_id:
                 record.partner_name = record.partner_id.name
-            if (record.folio_id and not record.partner_name) or (
-                record.folio_id
-                and record.folio_id.partner_name
-                and record.folio_id.partner_name != record.partner_name
-            ):
+            elif not record.partner_name and record.folio_id.partner_name:
+                # Fall back to the folio holder only when the reservation has
+                # no guest name of its own: on group/company folios the folio
+                # is held by the company while each reservation keeps the
+                # name of its occupant, which must not be overwritten.
                 record.partner_name = record.folio_id.partner_name
             elif record.agency_id and not record.partner_name:
                 # if the customer not is the agency but we dont know the customer's
@@ -2057,7 +2061,12 @@ class PmsReservation(models.Model):
             if vals.get("folio_id"):
                 folio = self.env["pms.folio"].browse(vals["folio_id"])
                 default_vals = {"pms_property_id": folio.pms_property_id.id}
-                if folio.partner_id:
+                if vals.get("partner_id") or vals.get("partner_name"):
+                    # The caller sets the reservation guest explicitly: it
+                    # can differ from the folio holder (e.g. group/company
+                    # folios), so don't inherit the folio identity
+                    pass
+                elif folio.partner_id:
                     default_vals["partner_id"] = folio.partner_id.id
                 elif folio.partner_name:
                     default_vals["partner_name"] = folio.partner_name

--- a/pms/tests/test_pms_reservation.py
+++ b/pms/tests/test_pms_reservation.py
@@ -1791,6 +1791,121 @@ class TestPmsReservations(TestPms, AccountTestInvoicingCommon):
         )
 
     @freeze_time("2012-01-14")
+    def test_reservation_guest_name_not_overwritten_by_folio(self):
+        """
+        Check that a reservation with its own partner_name (the guest)
+        keeps it when the folio is held by another partner (e.g. a
+        company folio with the guest names per reservation)
+        ----------
+        Create a folio held by a company partner. Then create a
+        reservation in that folio with an explicit partner_name.
+        The reservation must keep the guest name and the folio must
+        keep the company name.
+        """
+        # ARRANGE
+        company = self.env["res.partner"].create(
+            {
+                "name": "Company Holder",
+                "is_company": True,
+            }
+        )
+        folio = self.env["pms.folio"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "partner_id": company.id,
+            }
+        )
+        # ACT
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": "2012-01-14",
+                "checkout": "2012-01-17",
+                "pms_property_id": self.pms_property1.id,
+                "folio_id": folio.id,
+                "room_type_id": self.room_type_double.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "partner_name": "Guest Name",
+            }
+        )
+        reservation.flush_recordset()
+        reservation.invalidate_recordset(["partner_name", "partner_id"])
+        # ASSERT
+        self.assertEqual(
+            reservation.partner_name,
+            "Guest Name",
+            "The reservation guest name was overwritten by the folio " "partner name",
+        )
+        self.assertEqual(
+            reservation.partner_id,
+            company,
+            "The reservation billing partner must stay the folio holder",
+        )
+        self.assertEqual(
+            folio.partner_name,
+            company.name,
+            "The folio partner name doesn't correspond to the company",
+        )
+
+    @freeze_time("2012-01-14")
+    def test_folio_rename_only_propagates_to_inherited_names(self):
+        """
+        Check that renaming the folio partner_name propagates to the
+        reservations that inherited the folio name but not to the
+        reservations with their own guest name
+        ----------
+        Create a folio with partner_name and two reservations: one
+        without partner_name (inherits the folio name) and one with an
+        explicit guest name. Rename the folio partner_name and check
+        that only the inherited one is updated.
+        """
+        # ARRANGE
+        folio = self.env["pms.folio"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "partner_name": "Original Holder",
+            }
+        )
+        inherited_reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": "2012-01-14",
+                "checkout": "2012-01-17",
+                "pms_property_id": self.pms_property1.id,
+                "folio_id": folio.id,
+                "room_type_id": self.room_type_double.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+        guest_reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": "2012-01-14",
+                "checkout": "2012-01-17",
+                "pms_property_id": self.pms_property1.id,
+                "folio_id": folio.id,
+                "room_type_id": self.room_type_double.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+                "partner_name": "Guest Name",
+            }
+        )
+        # ACT
+        folio.write({"partner_name": "New Holder"})
+        (inherited_reservation | guest_reservation).flush_recordset()
+        (inherited_reservation | guest_reservation).invalidate_recordset(
+            ["partner_name"]
+        )
+        # ASSERT
+        self.assertEqual(
+            inherited_reservation.partner_name,
+            "New Holder",
+            "The folio rename wasn't propagated to the reservation "
+            "that inherited the folio name",
+        )
+        self.assertEqual(
+            guest_reservation.partner_name,
+            "Guest Name",
+            "The folio rename overwrote the reservation guest name",
+        )
+
+    @freeze_time("2012-01-14")
     def test_partner_is_agency_not_invoice_to_agency(self):
         """
         Check that a reservation without partner_name but with


### PR DESCRIPTION
On group/company folios the folio is held by a company partner while each reservation keeps the name of its occupant. This is a common scenario with external integrations (channel managers / OTAs with corporate or retail-agency accounts): the booking account owns the folio and every reservation carries the guest that will actually stay.

**Bug**

Any guest name set explicitly on the reservation (`partner_name`) was lost through three paths:

1. `pms.reservation.create()` builds `default_vals` from the folio identity and `vals.update()`s them over the caller's vals, so an explicit `partner_name` / `email` / `mobile` was overwritten by the folio's values at creation.
2. `pms.reservation._compute_partner_name` overwrote the reservation's own `partner_name` with `folio_id.partner_name` whenever they differed.
3. The compute depended on `folio_id.partner_name`, so any folio rename triggered a recompute of all its reservations; inside that recompute the reservation's own stored `partner_name` is not readable (the cache was just invalidated), which made the folio name always win.

**Fix**

- `create()`: the folio identity defaults are only applied when the caller does not set the guest explicitly (`partner_id` / `partner_name` in vals).
- `_compute_partner_name`: proper priority chain — reservation `partner_id` > own `partner_name` > folio `partner_name` > agency placeholder. The folio name is now only a fallback when the reservation has no name of its own.
- The `folio_id.partner_name` dependency is removed and folio holder renames are propagated from `pms.folio.write()` instead, following the same pattern already used there for `sale_channel_origin_id`: only reservations that inherited the previous folio name (or have none) are renamed, covering renames both via `partner_name` and via `partner_id`. This keeps the behavior introduced in 7835b5394 ("improve compute partner name in reservation model when changing folio partner name") for the inherited-name case, while explicit guest names are left untouched.

The reservation billing partner (`partner_id`) keeps inheriting the folio holder as before; the guest identity lives in `partner_name` / `email` / `mobile` and possible divergences are already surfaced by `partner_incongruences`.

**Tests**

- `test_reservation_guest_name_not_overwritten_by_folio`: a reservation created with an explicit guest name in a folio held by a company keeps the guest name (checked against the stored value, not the cache).
- `test_folio_rename_only_propagates_to_inherited_names`: renaming the folio updates the reservations that inherited the folio name and keeps explicit guest names.
- Existing `test_partner_name_folio` (inheritance when the reservation has no name) and `test_partner_is_agency_not_invoice_to_agency` (agency placeholder) still pass, as does the rest of the module suite (the only failures on a clean install are pre-existing on 16.0 and unrelated: fiscal position priority and payment method line).
