### PR TITLE
[16.0][FIX] pms: hide PMS-only fields from users without PMS access

### DIFF
--- a/pms/views/product_pricelist_item_views.xml
+++ b/pms/views/product_pricelist_item_views.xml
@@ -6,10 +6,15 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='applied_on']" position="before">
                 <field name="allowed_board_service_product_ids" invisible="1" />
-                <field name="allowed_board_service_room_type_ids" invisible="1" />
+                <field
+                    name="allowed_board_service_room_type_ids"
+                    invisible="1"
+                    groups="pms.group_pms_user"
+                />
 
                 <field
                     name="board_service_room_type_id"
+                    groups="pms.group_pms_user"
                     options="{'no_create': True,'no_open': True}"
                     domain="[('id', 'in',allowed_board_service_room_type_ids)]"
                 />
@@ -18,6 +23,7 @@
             <xpath expr="//field[@name='min_quantity']" position="before">
                 <field
                     name="pms_property_ids"
+                    groups="pms.group_pms_user"
                     widget="many2many_tags"
                     options="{'no_create': True,'no_open': True}"
                 />

--- a/pms/views/product_pricelist_views.xml
+++ b/pms/views/product_pricelist_views.xml
@@ -8,6 +8,7 @@
                 <field name="is_pms_available" />
                 <field
                     name="pms_property_ids"
+                    groups="pms.group_pms_user"
                     widget="many2many_tags"
                     options="{'no_create': True,'no_open': True}"
                     attrs="{'invisible': [('is_pms_available', '=', False)]}"
@@ -16,18 +17,22 @@
             <xpath expr="//field[@name='country_group_ids']" position="before">
                 <field
                     name="pricelist_type"
+                    groups="pms.group_pms_user"
                     attrs="{'invisible': [('is_pms_available', '=', False)]}"
                 />
                 <field
                     name="cancelation_rule_id"
+                    groups="pms.group_pms_user"
                     attrs="{'invisible': [('is_pms_available', '=', False)]}"
                 />
                 <field
                     name="availability_plan_id"
+                    groups="pms.group_pms_user"
                     attrs="{'invisible': [('is_pms_available', '=', False)]}"
                 />
                 <field
                     name="pms_sale_channel_ids"
+                    groups="pms.group_pms_user"
                     widget="many2many_tags"
                     attrs="{'invisible': [('is_pms_available', '=', False)]}"
                 />

--- a/pms/views/product_template_views.xml
+++ b/pms/views/product_template_views.xml
@@ -9,6 +9,7 @@
                 <field name="is_pms_available" />
                 <field
                     name="pms_property_ids"
+                    groups="pms.group_pms_user"
                     widget="many2many_tags"
                     options="{'no_create': True,'no_open': True}"
                     attrs="{'invisible': [('is_pms_available', '=', False)]}"
@@ -17,6 +18,7 @@
             <xpath expr="//page[@name='sales']" position="before">
                 <page
                     string="PMS Service"
+                    groups="pms.group_pms_user"
                     attrs="{'invisible': [('is_pms_available', '=', False)]}"
                 >
                     <group colspan="4">

--- a/pms/views/res_partner_views.xml
+++ b/pms/views/res_partner_views.xml
@@ -34,7 +34,6 @@
         <field name="name">res.partner.view.form</field>
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
-        <!--<field name="groups_id" eval="[(4, ref('pms.group_pms_user'))]" />-->
         <field name="arch" type="xml">
             <xpath expr='//div[@name="button_box"]' position='inside'>
                 <button
@@ -42,6 +41,7 @@
                     type="object"
                     icon="fa-bed"
                     name="action_partner_reservations"
+                    groups="pms.group_pms_user"
                     help="Reservations related with this contact"
                 >
                     <field
@@ -55,6 +55,7 @@
                     type="object"
                     icon="fa-file"
                     name="action_partner_folios"
+                    groups="pms.group_pms_user"
                     help="Folios related with this contact"
                 >
                     <field string="Folios" name="folios_count" widget="statinfo" />
@@ -69,12 +70,17 @@
                 expr="//notebook/page[@name='sales_purchases']/group/group/field[@name='company_id']"
                 position="after"
             >
-                <field name="pms_property_ids" widget="many2many_tags" />
+                <field
+                    name="pms_property_ids"
+                    widget="many2many_tags"
+                    groups="pms.group_pms_user"
+                />
             </xpath>
             <xpath expr="//page[@name='internal_notes']" position="after">
                 <page
                     name="agency"
                     string="Agency"
+                    groups="pms.group_pms_user"
                     attrs="{'invisible':[('is_agency','!=',True)]}"
                 >
                     <group>


### PR DESCRIPTION
## Problem

On a database where the PMS coexists with other business lines, any internal user **without** a PMS group gets an `AccessError` when opening plain business forms:

> You are not allowed to access 'Partner Checkins' (pms.checkin.partner) records.

The views this module inherits add PMS fields without any group restriction, and those fields (or their computes) read PMS models whose ACLs are limited to `pms.group_pms_user` / `pms.group_pms_manager`:

| Form | Field | Model it reads |
|---|---|---|
| `res.partner` | `reservations_count` (compute) | `pms.checkin.partner` |
| `product.template` / `product.product` | `property_daily_limits` | `ir.pms.property` |
| `product.pricelist` | `pms_sale_channel_ids` | `pms.sale.channel` |
| `product.pricelist.item` | `allowed_board_service_room_type_ids` | `pms.board.service.room.type` |

It goes unnoticed on hotel-only databases, where every internal user has a PMS group. It shows up as soon as the same Odoo hosts staff unrelated to the property (accounting, sales, another business unit), who then cannot open a contact, a product or a pricelist at all.

## How to reproduce

1. Take a user with `base.group_user` (and, to rule out unrelated ACLs, `base.group_system`) and **no** PMS group.
2. Open any contact form → `AccessError` on `pms.checkin.partner`.
3. Same with a product, a pricelist and a pricelist item, on the models listed above.

## Fix

Add `groups="pms.group_pms_user"` to those elements, so they are dropped from the arch for users without PMS access while the rest of the form stays usable.

Whole blocks are guarded rather than only the offending field: when a guarded field is referenced from the `attrs` or `domain` of a sibling that stays visible (`is_pms_available` on the pricelist, `allowed_board_service_room_type_ids` in the domain of `board_service_room_type_id`), hiding it alone breaks the view for a different reason.

The commented-out `groups_id` line on the `res.partner` view is dropped as well: Odoo 16 rejects `groups_id` on inherited views (*"Inherited view cannot have 'groups' defined in the record"*), so the `groups` attribute is the supported mechanism.

## Testing

Verified on a production database hosting a hotel plus an unrelated business line, with three profiles — an administrator without PMS groups, a plain internal user, and a PMS manager — across `res.partner`, `product.template`, `product.product`, `product.pricelist`, `product.pricelist.item`, `account.journal`, `account.move`, `account.move.line`, `account.payment`, `account.bank.statement`, `res.users` and `res.company`: no access errors after the change, and users **with** PMS groups keep seeing every PMS field as before.