### PR TITLE
[16.0][FIX] pms: keep pms_property_ids available when restricting it by group

### DIFF
--- a/multi_pms_properties/README.rst
+++ b/multi_pms_properties/README.rst
@@ -59,6 +59,15 @@ Usage
   ``check_pms_properties like field attribute to check relational record properties consistence``
   ``This module not implement propety dependent fields``
 
+* ``check_pms_properties`` injects a domain referring to the property field of the
+  model, so any view showing such a field must keep ``pms_property_id(s)``
+  available for every group combination. Restricting it with ``groups`` makes Odoo
+  refuse to validate the view. To hide it from some users, add a companion node
+  instead, the same way core does with ``company_id`` and ``check_company``::
+
+    <field name="pms_property_ids" groups="pms.group_pms_user" />
+    <field name="pms_property_ids" groups="!pms.group_pms_user" invisible="1" />
+
 Bug Tracker
 ===========
 

--- a/multi_pms_properties/readme/USAGE.rst
+++ b/multi_pms_properties/readme/USAGE.rst
@@ -3,3 +3,12 @@
   ``_check_pms_properties_auto like model attribute to autocheck  on create/write``
   ``check_pms_properties like field attribute to check relational record properties consistence``
   ``This module not implement propety dependent fields``
+
+* ``check_pms_properties`` injects a domain referring to the property field of the
+  model, so any view showing such a field must keep ``pms_property_id(s)``
+  available for every group combination. Restricting it with ``groups`` makes Odoo
+  refuse to validate the view. To hide it from some users, add a companion node
+  instead, the same way core does with ``company_id`` and ``check_company``::
+
+    <field name="pms_property_ids" groups="pms.group_pms_user" />
+    <field name="pms_property_ids" groups="!pms.group_pms_user" invisible="1" />

--- a/multi_pms_properties/static/description/index.html
+++ b/multi_pms_properties/static/description/index.html
@@ -406,6 +406,16 @@ or with the <tt class="docutils literal"><span class="pre">--load</span></tt> co
 <tt class="docutils literal">check_pms_properties like field attribute to check relational record properties consistence</tt>
 <tt class="docutils literal">This module not implement propety dependent fields</tt></p>
 </li>
+<li><p class="first"><tt class="docutils literal">check_pms_properties</tt> injects a domain referring to the property field of the
+model, so any view showing such a field must keep <tt class="docutils literal">pms_property_id(s)</tt>
+available for every group combination. Restricting it with <tt class="docutils literal">groups</tt> makes Odoo
+refuse to validate the view. To hide it from some users, add a companion node
+instead, the same way core does with <tt class="docutils literal">company_id</tt> and <tt class="docutils literal">check_company</tt>:</p>
+<pre class="literal-block">
+&lt;field name=&quot;pms_property_ids&quot; groups=&quot;pms.group_pms_user&quot; /&gt;
+&lt;field name=&quot;pms_property_ids&quot; groups=&quot;!pms.group_pms_user&quot; invisible=&quot;1&quot; /&gt;
+</pre>
+</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">

--- a/pms/tests/__init__.py
+++ b/pms/tests/__init__.py
@@ -46,3 +46,4 @@ from . import test_pms_tourist_tax
 from . import test_pms_payment
 from . import test_res_partner
 from . import test_pms_property
+from . import test_view_check_pms_properties

--- a/pms/tests/test_view_check_pms_properties.py
+++ b/pms/tests/test_view_check_pms_properties.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Commit [Sun]
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from unittest.mock import patch
+
+from odoo import fields
+from odoo.tests import common
+
+from odoo.addons.multi_pms_properties import _description_domain
+
+
+class TestViewCheckPmsProperties(common.TransactionCase):
+    """Views must keep the property field available for every group combination.
+
+    ``multi_pms_properties`` injects a domain into every relational field declared
+    with ``check_pms_properties=True``, and that domain refers to the property
+    field of the model (``pms_property_ids`` or ``pms_property_id``). Odoo refuses
+    to validate a view where a field used in the domain of another field is
+    restricted to a narrower group, so restricting the property field with
+    ``groups`` breaks the whole view, and with it the module load.
+
+    The injection only happens when ``multi_pms_properties`` is loaded through
+    ``server_wide_modules``, which is not the case while running tests. The patch
+    is therefore applied explicitly here, so the check reproduces a real
+    deployment instead of silently passing.
+    """
+
+    # Views showing fields whose injected domain refers to the property field
+    VIEWS = [
+        "pms.product_pricelist_view_form",
+        "pms.product_pricelist_item_view_form",
+        "pms.product_template_view_form",
+        "pms.res_partner_view_form",
+    ]
+
+    def test_views_validate_with_injected_property_domain(self):
+        with patch.object(
+            fields._Relational, "check_pms_properties", False, create=True
+        ), patch.object(
+            fields._Relational, "_description_domain", _description_domain, create=True
+        ):
+            for xml_id in self.VIEWS:
+                with self.subTest(view=xml_id):
+                    self.env.ref(xml_id)._check_xml()

--- a/pms/views/product_pricelist_item_views.xml
+++ b/pms/views/product_pricelist_item_views.xml
@@ -27,6 +27,14 @@
                     widget="many2many_tags"
                     options="{'no_create': True,'no_open': True}"
                 />
+                <!-- Kept available (hidden) for non PMS users: the domain
+                     injected by multi_pms_properties into product_tmpl_id and
+                     pricelist_id refers to pms_property_ids. -->
+                <field
+                    name="pms_property_ids"
+                    groups="!pms.group_pms_user"
+                    invisible="1"
+                />
             </xpath>
             <xpath expr="//field[@name='min_quantity']" position="after">
                 <label for="date_start_consumption" string="Consumption" />

--- a/pms/views/product_pricelist_views.xml
+++ b/pms/views/product_pricelist_views.xml
@@ -13,6 +13,17 @@
                     options="{'no_create': True,'no_open': True}"
                     attrs="{'invisible': [('is_pms_available', '=', False)]}"
                 />
+                <!-- multi_pms_properties injects a domain referring to
+                     pms_property_ids into every relational field of this model
+                     declared with check_pms_properties=True, item_ids among them.
+                     A view cannot use a field restricted to a narrower group, so
+                     the field must stay available (hidden) for the other users.
+                     Same pattern as company_id/check_company in core views. -->
+                <field
+                    name="pms_property_ids"
+                    groups="!pms.group_pms_user"
+                    invisible="1"
+                />
             </xpath>
             <xpath expr="//field[@name='country_group_ids']" position="before">
                 <field


### PR DESCRIPTION
Regression from #440.

## Problem

`multi_pms_properties` injects a domain into every relational field declared with
`check_pms_properties=True`, and that domain refers to the property field of the model:

https://github.com/OCA/pms/blob/16.0/multi_pms_properties/__init__.py#L51-L54

```python
return f"['|', '|', \
    (not {prop1}, '=', True), \
    ('{coprop}', 'in', {prop2}), \
    ('{coprop}', '=', False)]"
```

On `product.pricelist` five fields carry that domain, `item_ids` among them, and on
`product.pricelist.item` four do, `product_tmpl_id` and `pricelist_id` among them. All of
them are displayed by the inherited core views **without any group**.

Odoo refuses to validate a view where a field used in the domain of another field is
restricted to a narrower group ([`ir_ui_view.py#L3053`](https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/models/ir_ui_view.py)),
so adding `groups="pms.group_pms_user"` to `pms_property_ids` breaks the whole view:

```
odoo.tools.convert.ParseError: while parsing pms/views/product_pricelist_views.xml:3
Field 'pms_property_ids' used in domain of field 'item_ids'
(['|', '|', (not pms_property_ids, '=', True), ('pms_property_ids', 'in', pms_property_ids),
('pms_property_ids', '=', False)]) is restricted to the group(s) pms.group_pms_user.
```

The view no longer loads, so `pms` cannot be installed or updated on any database with
`multi_pms_properties` loaded through `server_wide_modules`. It is not a cosmetic issue.

## Why CI did not catch it

The domain injection is gated on `multi_pms_properties` being in `server_wide_modules`,
which is not the case when running the test suite, so the injected domain never exists
there and the views validate fine.

For the record, I could not pin down why a fresh install passes while updating an existing
database fails, even with the patch active in both. I would rather say so than guess: the
failure is reproducible on update, and the fix below is correct regardless of the trigger.

## Fix

Keep the field available for the remaining users with a hidden companion node, which is
the pattern core uses for `company_id` with `check_company` (61 occurrences of `groups="!"`
in core views), for instance
[`account_move_views.xml#L417-L418`](https://github.com/odoo/odoo/blob/16.0/addons/account/views/account_move_views.xml):

```xml
<field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" optional="hide"/>
<field name="company_id" groups="!base.group_multi_company" invisible="1"/>
```

The field stays *available* in the arch for every group combination while it is only
*displayed* to PMS users, so the intent of #440 is preserved.

Only two views need it. `product_template_views.xml` and `res_partner_views.xml` are left
untouched on purpose: the only `check_pms_properties` field of those models is
`pms_property_ids` itself, which is restricted to the same group that makes it mandatory,
so it is self-consistent.

## Test

`pms/tests/test_view_check_pms_properties.py` validates the affected views with the domain
injection patched in explicitly, so it does not depend on `server_wide_modules` and
reproduces a real deployment instead of silently passing.

To be clear about what I did and did not verify: the failure and the fix are confirmed on
an update of an existing database, but I have not run this test suite myself, so I am
relying on this PR's CI for it. Please double check that it does fail without the view
changes; if it does not, the trigger is narrower than the test assumes and the test needs
work before it is worth keeping.

Also documented the invariant in `multi_pms_properties` usage, since this is an easy trap
to fall into again from any module adding `groups` to a property field.
