### PR TITLE
[16.0][FIX] pms: check room capacity when the room of a reservation changes

### DIFF
--- a/pms/models/pms_reservation.py
+++ b/pms/models/pms_reservation.py
@@ -2218,6 +2218,11 @@ class PmsReservation(models.Model):
             # (p.e. flush) that not take access to possible extra beds service in vals
             if "adults" in vals:
                 record._check_capacity()
+            # The room of the lines is recomputed from the preferred room, so
+            # that write does not go through pms.reservation.line.write and the
+            # capacity of the new room would not be checked anywhere
+            if "preferred_room_id" in vals:
+                record.reservation_line_ids._check_room_capacity()
             if (
                 "checkin" in vals
                 or "checkout" in vals

--- a/pms/models/pms_reservation_line.py
+++ b/pms/models/pms_reservation_line.py
@@ -672,7 +672,39 @@ class PmsReservationLine(models.Model):
         ):
             raise ValidationError(_("Blocked reservations can't be modified"))
         res = super().write(vals)
+        if vals.get("room_id"):
+            self._check_room_capacity()
         return res
+
+    def _check_room_capacity(self):
+        """Check that the room can hold the occupancy of the reservation.
+
+        pms.reservation only checks the capacity on create and when 'adults'
+        change, so changing the room (planning drag&drop, room swap or a new
+        preferred room) was not validated at all. We use the maximum capacity
+        of the room (capacity + allowed extra beds) instead of the extra beds
+        actually sold, to avoid false positives in intermediate states where
+        the extra bed service is not created yet.
+        """
+        if self.env.context.get("avoid_capacity_check"):
+            return
+        for record in self:
+            reservation = record.reservation_id
+            if not record.room_id or reservation.reservation_type == "out":
+                continue
+            occupancy = reservation.adults + reservation.children_occupying
+            max_capacity = record.room_id.capacity + record.room_id.extra_beds_allowed
+            if occupancy > max_capacity:
+                raise ValidationError(
+                    _(
+                        "The room %(room)s can't hold %(occupancy)s guests "
+                        "(maximum capacity: %(capacity)s) (%(reservation)s)",
+                        room=record.room_id.display_name,
+                        occupancy=occupancy,
+                        capacity=max_capacity,
+                        reservation=reservation.name,
+                    )
+                )
 
     # Constraints and onchanges
     @api.constrains("date")

--- a/pms/tests/test_pms_reservation_line.py
+++ b/pms/tests/test_pms_reservation_line.py
@@ -348,3 +348,160 @@ class TestPmsReservationLines(TestPms):
             all(reservation.reservation_line_ids.room_id.mapped("active")),
             "All rooms auto-assigned to a reservation must be active",
         )
+
+    @freeze_time("2000-12-01")
+    def test_move_reservation_to_room_without_capacity(self):
+        """
+        Check that a reservation cannot be moved to a room that
+        cannot hold its occupancy.
+
+        The capacity was only checked on create and when the number of adults
+        changed, so moving the reservation to a smaller room (planning
+        drag&drop, room swap, ...) allowed to overload the room.
+        """
+        # ARRANGE
+        single_room = self.env["pms.room"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "name": "Single 105",
+                "room_type_id": self.room_type_double.id,
+                "capacity": 1,
+                "extra_beds_allowed": 0,
+            }
+        )
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": fields.date.today(),
+                "checkout": fields.date.today() + datetime.timedelta(days=3),
+                "preferred_room_id": self.room1.id,
+                "adults": 2,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+
+        # ACT & ASSERT
+        with self.assertRaises(
+            ValidationError,
+            msg="A reservation of 2 adults should not fit in a room for 1",
+        ):
+            reservation.reservation_line_ids.write({"room_id": single_room.id})
+
+    @freeze_time("2000-12-01")
+    def test_change_preferred_room_without_capacity(self):
+        """
+        Check that the capacity is also checked when the room is changed
+        through the preferred room of the reservation, whose recompute of
+        the room of the lines does not go through pms.reservation.line.write.
+        """
+        # ARRANGE
+        single_room = self.env["pms.room"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "name": "Single 106",
+                "room_type_id": self.room_type_double.id,
+                "capacity": 1,
+                "extra_beds_allowed": 0,
+            }
+        )
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": fields.date.today(),
+                "checkout": fields.date.today() + datetime.timedelta(days=3),
+                "preferred_room_id": self.room1.id,
+                "adults": 2,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+
+        # ACT & ASSERT
+        with self.assertRaises(
+            ValidationError,
+            msg="A reservation of 2 adults should not fit in a room for 1",
+        ):
+            reservation.write({"preferred_room_id": single_room.id})
+
+    @freeze_time("2000-12-01")
+    def test_move_reservation_to_room_with_extra_beds(self):
+        """
+        Check that a reservation can be moved to a room whose capacity is
+        only enough with its allowed extra beds.
+
+        The extra bed services are not always created yet when the room
+        changes, so the allowed extra beds of the room are taken into account
+        to avoid blocking legitimate room changes.
+        """
+        # ARRANGE
+        extra_bed_room = self.env["pms.room"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "name": "Single 107",
+                "room_type_id": self.room_type_double.id,
+                "capacity": 1,
+                "extra_beds_allowed": 1,
+            }
+        )
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": fields.date.today(),
+                "checkout": fields.date.today() + datetime.timedelta(days=3),
+                "preferred_room_id": self.room1.id,
+                "adults": 2,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+
+        # ACT
+        reservation.reservation_line_ids.write({"room_id": extra_bed_room.id})
+
+        # ASSERT
+        self.assertEqual(
+            reservation.reservation_line_ids.room_id,
+            extra_bed_room,
+            "The reservation should fit in a room with an allowed extra bed",
+        )
+
+    @freeze_time("2000-12-01")
+    def test_move_reservation_avoiding_capacity_check(self):
+        """
+        Check that the capacity check on room changes can be skipped
+        through the context, to allow massive or automated changes.
+        """
+        # ARRANGE
+        single_room = self.env["pms.room"].create(
+            {
+                "pms_property_id": self.pms_property1.id,
+                "name": "Single 108",
+                "room_type_id": self.room_type_double.id,
+                "capacity": 1,
+                "extra_beds_allowed": 0,
+            }
+        )
+        reservation = self.env["pms.reservation"].create(
+            {
+                "checkin": fields.date.today(),
+                "checkout": fields.date.today() + datetime.timedelta(days=3),
+                "preferred_room_id": self.room1.id,
+                "adults": 2,
+                "partner_id": self.partner1.id,
+                "pms_property_id": self.pms_property1.id,
+                "sale_channel_origin_id": self.sale_channel_direct.id,
+            }
+        )
+
+        # ACT
+        reservation.reservation_line_ids.with_context(avoid_capacity_check=True).write(
+            {"room_id": single_room.id}
+        )
+
+        # ASSERT
+        self.assertEqual(
+            reservation.reservation_line_ids.room_id,
+            single_room,
+            "The capacity check should be skipped with avoid_capacity_check",
+        )


### PR DESCRIPTION
## Problem

The room capacity check used to be a constraint on `pms.reservation`. It was
turned into a manual check called from `create()` and from `write()` only when
`adults` is in vals, to avoid false positives in intermediate states where the
extra bed services of the vals are not accessible yet.

As a side effect, **no room change validates the capacity any more**:

- writing `room_id` on the reservation lines (planning drag&drop, room swap,
  split/join/swap wizard), and
- changing `preferred_room_id` on the reservation, whose recompute of the room
  of the lines does not go through `pms.reservation.line.write()`,

both allow moving a reservation to a room that cannot hold its guests (e.g. a
2 pax reservation into a single room), with the overoccupancy that follows.

## Solution

Check the capacity of the new room on both paths, in a new
`pms.reservation.line._check_room_capacity()`.

To keep away from the false positives that motivated the manual check, it uses
the **maximum** capacity of the room (`capacity + extra_beds_allowed`) instead
of the extra beds actually sold, so a room change is never blocked because the
extra bed service is not created yet. The check can be skipped with the
`avoid_capacity_check` context key for massive or automated changes.

## Tests

Four tests in `test_pms_reservation_line.py`: the room change is blocked both
by line and by preferred room, it is allowed when the destination room has an
allowed extra bed, and the context key skips it.

@commitsun

🤖 Generated with [Claude Code](https://claude.com/claude-code)