### PR TITLE
[16.0][FIX] pms: count bank statement payments in the folio pending amount

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -1249,6 +1249,13 @@ class PmsFolio(models.Model):
         "payment_ids.move_id.line_ids.credit",
         "payment_ids.move_id.line_ids.currency_id",
         "payment_ids.move_id.line_ids.amount_currency",
+        "statement_line_ids.move_id",
+        "statement_line_ids.move_id.line_ids",
+        "statement_line_ids.move_id.line_ids.date",
+        "statement_line_ids.move_id.line_ids.debit",
+        "statement_line_ids.move_id.line_ids.credit",
+        "statement_line_ids.move_id.line_ids.currency_id",
+        "statement_line_ids.move_id.line_ids.amount_currency",
         "move_ids.amount_residual",
     )
     def _compute_amount(self):
@@ -1263,26 +1270,24 @@ class PmsFolio(models.Model):
                 record.update(vals)
             else:
                 # first attempt compute amount search payments refs with only one folio
-                mls_one_folio = (
-                    record.payment_ids.filtered(lambda pay: len(pay.folio_ids) == 1)
-                    .mapped("move_id.line_ids")
-                    .filtered(
-                        lambda x: x.account_id.account_type == "asset_receivable"
-                        and x.parent_state == "posted"
-                    )
+                mls_one_folio = record._get_payment_move_lines(
+                    record.payment_ids.filtered(lambda pay: len(pay.folio_ids) == 1),
+                    record.statement_line_ids.filtered(
+                        lambda st: len(st.folio_ids) == 1
+                    ),
                 )
                 advance_amount = record._get_advance_amount(mls_one_folio)
                 # Compute 'payment_state'.
                 vals = record._get_amount_vals(mls_one_folio, advance_amount)
                 # If folio its not paid, search payments refs with more than one folio
-                folio_ids = record.payment_ids.mapped("folio_ids.id")
+                folio_ids = list(
+                    set(record.payment_ids.mapped("folio_ids.id"))
+                    | set(record.statement_line_ids.mapped("folio_ids.id"))
+                )
                 if vals["pending_amount"] > 0 and len(folio_ids) > 1:
                     folios = self.env["pms.folio"].browse(folio_ids)
-                    mls_multi_folio = folios.payment_ids.mapped(
-                        "move_id.line_ids"
-                    ).filtered(
-                        lambda x: x.account_id.account_type == "asset_receivable"
-                        and x.parent_state == "posted"
+                    mls_multi_folio = record._get_payment_move_lines(
+                        folios.payment_ids, folios.statement_line_ids
                     )
                     if mls_multi_folio:
                         advance_amount = record._get_advance_amount(mls_multi_folio)
@@ -1291,6 +1296,25 @@ class PmsFolio(models.Model):
                         )
 
                 record.update(vals)
+
+    def _get_payment_move_lines(self, payments, statement_lines):
+        """Return the receivable move lines of the given folio payments.
+
+        Both ways of collecting money from a guest are taken into account:
+        payments registered through the PMS (account.payment) and bank
+        statement lines linked to the folio. The latter is how a transfer
+        paid by the guest reaches the folio when the bank statement is
+        reconciled directly against the customer invoice, a common setup in
+        which no account.payment is ever created.
+        """
+        self.ensure_one()
+        mls = payments.mapped("move_id.line_ids") | statement_lines.mapped(
+            "move_id.line_ids"
+        )
+        return mls.filtered(
+            lambda x: x.account_id.account_type == "asset_receivable"
+            and x.parent_state == "posted"
+        )
 
     def _get_advance_amount(self, mls):
         self.ensure_one()


### PR DESCRIPTION
## Problem

A guest pays their stay by bank transfer. The accountant reconciles the bank statement line straight against the customer invoice — the standard flow when no payment was registered beforehand, and the usual one in small properties. The invoice is fully paid, but **the folio stays "to pay" forever**: `pending_amount` never goes down and reception sees an outstanding balance for a booking that was collected weeks ago.

The reason is that `pms.folio._compute_amount` looks only at `payment_ids` (`account.payment`). It ignores `statement_line_ids`, even though this module defines the relation on both sides:

- `pms.folio.statement_line_ids` (`pms/models/pms_folio.py`)
- `account.bank.statement.line.folio_ids` (`pms/models/account_bank_statement_line.py`)

So the data is there, and the user can link the statement line to the folio, but it has no effect on the amounts.

## Fix

Take the statement lines into account next to the payments, in both the single-folio and the multi-folio branches, through a small helper (`_get_payment_move_lines`) that keeps the existing filter: only receivable lines of posted entries.

That filter is what keeps the amount correct in the other flow too. When a statement line is reconciled against an `account.payment` through an outstanding account, the statement move has no receivable line — the outstanding account is an asset — so nothing is counted twice; the payment alone is counted, exactly as today.

The `@api.depends` is extended accordingly so the stored fields recompute when the statement line or its move changes.

## How to reproduce

1. Create a folio with a reservation and invoice it.
2. Register the guest's transfer as a bank statement line and reconcile it directly against that invoice (no `account.payment` involved).
3. Link the statement line to the folio (`folio_ids`).
4. Before this patch: the folio keeps `pending_amount = amount_total` and `payment_state = not_paid`. After it: the folio is settled.

## Testing

Verified on a production database of a rural property whose 19 opening bookings had been invoiced and collected by transfer before the PMS went live: with the statement lines linked, the folios were still showing 3.086 € pending. Existing behaviour for folios collected through the PMS is unchanged, since those go through `account.payment` as before.