### PR TITLE
[FIX] pms_sale: min_nights was never actually enforced

### DIFF
--- a/pms_sale/models/pms_reservation.py
+++ b/pms_sale/models/pms_reservation.py
@@ -246,17 +246,18 @@ class PmsReservation(models.Model):
     @api.constrains("property_id", "duration")
     def _check_no_of_nights(self):
         for rec in self:
-            if (
-                rec.duration > rec.property_id.min_nights
-                and rec.property_id.max_nights < rec.duration
-            ):
+            min_nights = rec.property_id.min_nights
+            max_nights = rec.property_id.max_nights
+            too_short = min_nights > 0 and rec.duration < min_nights
+            too_long = max_nights > 0 and rec.duration > max_nights
+            if too_short or too_long:
                 raise ValidationError(
                     self.env._(  # pylint: disable=W8301
                         "The number of nights must be between %(min)s and %(max)s."
                     )
                     % {
-                        "min": rec.property_id.min_nights,
-                        "max": rec.property_id.max_nights,
+                        "min": min_nights,
+                        "max": max_nights,
                     }
                 )
 

--- a/pms_sale/tests/test_pms_reservation.py
+++ b/pms_sale/tests/test_pms_reservation.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2022 Gray Matter Logic
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -77,6 +78,20 @@ class TestPMSReservation(TransactionCase):
 
     def test_check_no_of_nights(self):
         self.reservation._check_no_of_nights()
+
+    def test_check_no_of_nights_rejects_stay_below_minimum(self):
+        self.property.write({"min_nights": 2, "max_nights": 30})
+        with self.assertRaises(ValidationError):
+            self.reservation.write({"duration": 1})
+
+    def test_check_no_of_nights_rejects_fixed_length_stay_below_required(self):
+        self.property.write({"min_nights": 5, "max_nights": 5})
+        with self.assertRaises(ValidationError):
+            self.reservation.write({"duration": 3})
+
+    def test_check_no_of_nights_accepts_unconfigured_property(self):
+        self.property.write({"min_nights": 0, "max_nights": 0})
+        self.reservation.write({"duration": 2})
 
     def test_action_book(self):
         self.reservation.action_book()


### PR DESCRIPTION
## Bug

`pms.reservation._check_no_of_nights()` never actually enforces `min_nights`, regardless of its value. Its condition:

```python
if (
    rec.duration > rec.property_id.min_nights
    and rec.property_id.max_nights < rec.duration
):
    raise ValidationError(...)
```

only rejects a reservation when its duration exceeds **both** bounds at the same time — in practice this means only `max_nights` is ever checked, `min_nights` is dead code. Verified directly against a `pms.property`/`pms.reservation` pair:

| min_nights | max_nights | duration | result (before fix) |
|---|---|---|---|
| 2 | 30 | 1 night | accepted (should be rejected) |
| 5 | 5 | 3 nights | accepted (should be rejected) |
| 1 | 3 | 5 nights | rejected ✓ |
| 0 | 0 (default) | 2 nights | rejected |

## Fix

Corrected condition: `duration < min_nights or duration > max_nights`, treating `0` on either bound as "no limit" (the common Odoo convention for min/max quantity fields).

**Behavior change to flag for review:** previously, a property left at the default `min_nights=0`/`max_nights=0` rejected *every* reservation (with the confusing message "must be between 0 and 0"). With this fix, an unconfigured property now has no stay-length restriction at all, rather than being implicitly unbookable. I don't see anything in the field definitions, views, demo data or existing tests suggesting the old all-rejecting behavior was intentional (nothing marks 0 as a "not for rent" flag), but flagging explicitly in case there's context I'm missing.

## Tests

Added 3 regression tests to `pms_sale/tests/test_pms_reservation.py` covering: a too-short stay against a real `min_nights`, a fixed-length stay (`min_nights == max_nights`) below the required length, and an unconfigured (`0`/`0`) property. All go through `write()` (real `@api.constrains` dispatch), not a direct method call.

Ran the full `pms_sale` test suite locally (Odoo 19.0, PostgreSQL): 19/19 of the module's own tests pass with this change (one pre-existing, unrelated failure in `test_onchange_property_id` — a timezone-dependent assertion — is present identically on the unpatched `19.0` branch, confirmed by reverting and re-running).

Found while validating this module for a downstream project's data model.
