### PR TITLE
[16.0][FIX] pos_pms_link: offer reservations whose stay covers today

### DIFF
--- a/pos_pms_link/__manifest__.py
+++ b/pos_pms_link/__manifest__.py
@@ -21,7 +21,7 @@
 {
     "name": "POS PMS link",
     "summary": "Allows to use PMS reservations on the POS interface",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.0.1",
     "author": "Comunitea Servicios Tecnológicos S.L., Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/pms",
     "license": "AGPL-3",

--- a/pos_pms_link/models/pos_session.py
+++ b/pos_pms_link/models/pos_session.py
@@ -140,12 +140,11 @@ class PosSession(models.Model):
         return result
 
     def _loader_params_pms_reservation(self):
+        today = fields.Date.context_today(self)
         domain = [
-            "|",
-            ("state", "=", "onboard"),
-            "&",
-            ("checkout", "=", fields.Datetime.now().date()),
             ("state", "!=", "cancel"),
+            ("checkin", "<=", today),
+            ("checkout", ">=", today),
         ]
         if self.config_id and self.config_id.reservation_allowed_propertie_ids:
             domain.append(


### PR DESCRIPTION
### Problem

`pos.session._loader_params_pms_reservation()` loads the reservations offered in the POS with this domain:

```python
domain = [
    "|",
    ("state", "=", "onboard"),
    "&",
    ("checkout", "=", fields.Datetime.now().date()),
    ("state", "!=", "cancel"),
]
```

A reservation therefore reaches the POS only while it is `onboard`, or on its very last day. A stay that is confirmed but not yet checked in never appears, so the cashier cannot charge a consumption to it and the reservation-selection screen opens on an empty list.

That is reasonable for a hotel, where every guest is checked in on arrival. It makes the feature unusable for long stays: a reservation spanning weeks or months sits in `confirm` for its whole duration unless somebody performs a check-in, and a monthly-split stay gets a fresh segment whose checkout is weeks away. On a residence hall with ~250 rooms occupied for the whole academic year, the list was empty every single day.

### Fix

Load every non-cancelled reservation whose stay covers today, which is the single question the POS needs answered: can I charge this consumption to somebody who is staying right now.

```python
today = fields.Date.context_today(self)
domain = [
    ("state", "!=", "cancel"),
    ("checkin", "<=", today),
    ("checkout", ">=", today),
]
```

`checkout >= today` keeps the departure day included, which the old domain handled with its `checkout == today` branch, so a guest who checked out this morning can still be charged for breakfast.

This also replaces `fields.Datetime.now().date()` with `fields.Date.context_today()`. The former is UTC, so in a positive-offset timezone the date rolls over before local midnight and the evening shift loads the wrong day.

### On dropping the explicit `onboard` branch

I did first keep `onboard` as an alternative, and then removed it because it earns nothing: the only reservations it adds are those that are `onboard` *outside their own dates*, and `auto_departure_delayed()` already moves those to `departure_delayed` on the checkout day and auto-checks them out afterwards.

So this is not a strict superset of the old behaviour, and it is worth being explicit about the one case that changes: on an instance whose `nocheckout_reservations` cron is disabled, an overstay left in `onboard` past its checkout is no longer offered in the POS, and its dates have to be corrected first. I think that is the right trade — charging a consumption to a stay that the system believes ended yesterday hides the real problem — but I am happy to put the branch back if maintainers prefer strict compatibility.

### How to reproduce

1. On a POS config, tick *Pay on reservation*, set a *Pay on reservation method* and allow the property.
2. Create a reservation covering today that is `confirm` and not checked in.
3. Open the POS and press the reservation-selection button.

Before: the list is empty. After: the reservation is listed with its guest name, rooms and services.
