### PR TITLE
[16.0][FIX] pms: use account_type in the multi-folio amount compute

### DIFF
--- a/pms/models/pms_folio.py
+++ b/pms/models/pms_folio.py
@@ -1319,7 +1319,7 @@ class PmsFolio(models.Model):
                 self.payment_ids.filtered(lambda pay: len(pay.folio_ids) == 1)
                 .mapped("move_id.line_ids")
                 .filtered(
-                    lambda x: x.account_id.internal_type == "asset_receivable"
+                    lambda x: x.account_id.account_type == "asset_receivable"
                     and x.parent_state == "posted"
                 )
             )


### PR DESCRIPTION
`account.account.internal_type` was removed in Odoo 16 in favour of `account_type`, but the
multi-folio branch of `pms.folio._get_amount_vals` still used the old field:

https://github.com/OCA/pms/blob/16.0/pms/models/pms_folio.py#L1322

The two sibling call sites in `_compute_amount` were migrated; this one was missed.

### How to reproduce

`_compute_amount` only reaches that branch when a folio is **not fully paid** *and* one of its
payments is linked to more than one folio (`len(folio_ids) > 1`). Any flush that recomputes the
folio amounts then raises:

```
File "pms/models/pms_folio.py", line 1322, in <lambda>
    lambda x: x.account_id.internal_type == "asset_receivable"
AttributeError: 'account.account' object has no attribute 'internal_type'
```

We hit it on a folio of 407.82 sharing a 225.81 payment with a second folio: registering a
refund on it failed, but so would any other write invalidating `pending_amount` /
`payment_state`.

### Fix

One line, aligning it with the other two call sites. With the fix the refund is registered and
the folio amounts recompute as expected (`pending_amount` 407.82, `payment_state` `not_paid`).